### PR TITLE
タスクがないメンバー非表示チェックボックスを有効にすると遅くなる問題を修正

### DIFF
--- a/ProjectsTM/ViewModel/ViewData.cs
+++ b/ProjectsTM/ViewModel/ViewData.cs
@@ -63,6 +63,7 @@ namespace ProjectsTM.ViewModel
         {
             if (!Changed(filter)) return;
             Filter = filter;
+            AddFreeTimeMembersToHideMembers(GetFilteredMembers());
             FilterChanged(this, null);
         }
 
@@ -76,20 +77,23 @@ namespace ProjectsTM.ViewModel
         public IEnumerable<Member> GetFilteredMembers()
         {
             var result = CreateAllMembersList();
-            result = RemoveFilterSettingMembers(result);
-            return RemoveFreeTimeMembers(result);
+            return RemoveFilterSettingMembers(result);
         }
 
-        private IEnumerable<Member> RemoveFreeTimeMembers(IEnumerable<Member> members)
+        private void AddFreeTimeMembersToHideMembers(IEnumerable<Member> members)
         {
-            if (Filter == null || Filter.IsFreeTimeMemberShow) return members;
-            return members.Where(m => GetFilteredWorkItemsOfMember(m).HasWorkItem(Filter.Period));
+            if (Filter == null || Filter.IsFreeTimeMemberShow) return;
+            var freeTimeMember = members.Where(m => !GetFilteredWorkItemsOfMember(m).HasWorkItem(Filter.Period));
+            foreach (var m in freeTimeMember)
+            {
+                if (!Filter.HideMembers.Contains(m)) Filter.HideMembers.Add(m);
+            }
         }
 
-        private List<Member> RemoveFilterSettingMembers(List<Member> members)
+        private IEnumerable<Member> RemoveFilterSettingMembers(List<Member> members)
         {
             if (Filter == null || Filter.HideMembers == null) return members;
-            return members.Where(m => !Filter.HideMembers.Contains(m)).ToList();
+            return members.Where(m => !Filter.HideMembers.Contains(m));
         }
 
         private List<Member> CreateAllMembersList()

--- a/ProjectsTM/ViewModel/ViewData.cs
+++ b/ProjectsTM/ViewModel/ViewData.cs
@@ -90,10 +90,10 @@ namespace ProjectsTM.ViewModel
             }
         }
 
-        private IEnumerable<Member> RemoveFilterSettingMembers(List<Member> members)
+        private List<Member> RemoveFilterSettingMembers(List<Member> members)
         {
             if (Filter == null || Filter.HideMembers == null) return members;
-            return members.Where(m => !Filter.HideMembers.Contains(m));
+            return members.Where(m => !Filter.HideMembers.Contains(m)).ToList();
         }
 
         private List<Member> CreateAllMembersList()

--- a/ProjectsTM/ViewModel/ViewData.cs
+++ b/ProjectsTM/ViewModel/ViewData.cs
@@ -19,6 +19,7 @@ namespace ProjectsTM.ViewModel
             {
                 _appData = value;
                 UndoService = new UndoService();
+                AddFreeTimeMembersToHideMembers(GetFilteredMembers());
                 if (AppDataChanged != null) AppDataChanged(this, null);
             }
         }

--- a/ProjectsTM/ViewModel/ViewData.cs
+++ b/ProjectsTM/ViewModel/ViewData.cs
@@ -84,6 +84,7 @@ namespace ProjectsTM.ViewModel
         private void AddFreeTimeMembersToHideMembers(IEnumerable<Member> members)
         {
             if (Filter == null || Filter.IsFreeTimeMemberShow) return;
+            if (members == null || members.Count() > 0) return;
             var freeTimeMember = members.Where(m => !GetFilteredWorkItemsOfMember(m).HasWorkItem(Filter.Period));
             foreach (var m in freeTimeMember)
             {


### PR DESCRIPTION
概要
　RemoveFreeTimeMembers()の呼び出し元のGetFilterMember()は、
　色々な所から呼び出しているため、ここで少し重い処理をすると何倍にもなって効いてくる。

　RemoveFreeTimeMembers()　→　AddFreeTimeMembersToHideMembers()と関数名変更し、
　フィルターが反映されるタイミングでfreeTimeMembersをHideMembersへ自動追加するよう変更する。
　
　この変更により、
　　freeTimeMembersを表示させたい時は、フィルタ設定ダイアログにて、
　　　1、[タスクがないメンバーを表示する]チェックボックス をONする
　　　2,   表示したいfreeTimeMemberのチェックボックスをONする
　　の2段階操作が必要になる
　という仕様変更が生じる。


遅かった要因詳細
　private IEnumerable<Member> RemoveFreeTimeMembers(IEnumerable<Member> members) 
　内の
　return members.Where(m => GetFilteredWorkItemsOfMember(m).HasWorkItem(Filter.Period));
　にて
 　Original.WorkItemsのSortedDictionaryから全てのメンバーの WorkItemsを順番に取り出すところが遅かったよう。


