### PR TITLE
検索結果をCSVへコピペしやすいよう複数選択に対応

### DIFF
--- a/ProjectsTM/UI/SearchWorkitemForm.Designer.cs
+++ b/ProjectsTM/UI/SearchWorkitemForm.Designer.cs
@@ -127,7 +127,6 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView1.Location = new System.Drawing.Point(10, 35);
-            this.dataGridView1.MultiSelect = false;
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.ReadOnly = true;
             this.dataGridView1.RowTemplate.Height = 21;

--- a/ProjectsTM/UI/SearchWorkitemForm.cs
+++ b/ProjectsTM/UI/SearchWorkitemForm.cs
@@ -45,7 +45,7 @@ namespace ProjectsTM.UI
 
         private void dataGridView1_SelectionChanged(object sender, EventArgs e)
         {
-            if (dataGridView1.SelectedRows.Count <= 0) return;
+            if (dataGridView1.SelectedRows.Count != 1) return;
             if (dataGridView1.RowCount - 1 <= dataGridView1.SelectedRows[0].Index) return;
             var index = GetListIndexSelected(dataGridView1.SelectedRows);
             if (index < 0) return;
@@ -55,8 +55,8 @@ namespace ProjectsTM.UI
 
         private void dataGridView1_CellDoubleClick(object sender, DataGridViewCellEventArgs e)
         {
+            if (dataGridView1.SelectedRows.Count != 1) return;
             if (e.ColumnIndex < 0 || dataGridView1.ColumnCount <= e.ColumnIndex || e.RowIndex < 0 || dataGridView1.RowCount - 1 <= e.RowIndex) return;
-            if (dataGridView1.SelectedRows.Count <= 0) return;
             var index = GetListIndexSelected(dataGridView1.SelectedRows);
             if (index < 0) return;
             var wi = _list[index].Item1;
@@ -316,7 +316,7 @@ namespace ProjectsTM.UI
 
         private int GetListIndexSelected(DataGridViewSelectedRowCollection selectedRows)
         {
-            if (selectedRows.Count <= 0) return -1;
+            if (selectedRows.Count != 1) return -1;
             for (int result = 0; result < _list.Count; result++)
             {
                 if (Equal(_list[result].Item1, selectedRows[0].Cells)) return result;


### PR DESCRIPTION
・検索結果をCSVへこぴぺしやすいよう検索結果グリッドの複数選択に対応

・上記に伴い、検索結果グリッド選択で発生するイベント、関数では、「選択行数が1行か」を判定するように変更