### PR TITLE
タスクリスト上で項目を複数選択できるよう追加＋選択項目をCtrl＋Cでコピーできるよう追加

### DIFF
--- a/InnoSetupScripts.iss
+++ b/InnoSetupScripts.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "ProjectsTM"
-#define MyAppVersion GetFileVersion(SourcePath + "\ProjectsTM\bin\Release\ProjectsTM.exe")
+#define MyAppVersion GetFileVersion(SourcePath + "\ProjectsTM.exe\bin\Release\ProjectsTM.exe")
 #define MyAppPublisher "Keiya Shimomura"
 #define MyAppURL "https://github.com/skeiya/ProjectsTM"
 #define MyAppExeName "ProjectsTM.exe"
@@ -34,19 +34,19 @@ Name: "japanese"; MessagesFile: "compiler:Languages\Japanese.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: ".\ProjectsTM\bin\Release\FreeGridControl.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\Octokit.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\System.ValueTuple.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\ProjectsTM.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\ProjectsTM.exe.config"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\Help\help.html"; DestDir: "{app}\Help"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\ProjectsTM.Logic.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\ProjectsTM.Model.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\ProjectsTM.Service.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\ProjectsTM.UI.Common.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\ProjectsTM.UI.MainForm.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\ProjectsTM.UI.TaskList.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: ".\ProjectsTM\bin\Release\ProjectsTM.ViewModel.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\FreeGridControl.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\Octokit.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\System.ValueTuple.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\ProjectsTM.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\ProjectsTM.exe.config"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\Help\help.html"; DestDir: "{app}\Help"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\ProjectsTM.Logic.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\ProjectsTM.Model.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\ProjectsTM.Service.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\ProjectsTM.UI.Common.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\ProjectsTM.UI.MainForm.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\ProjectsTM.UI.TaskList.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: ".\ProjectsTM.exe\bin\Release\ProjectsTM.ViewModel.dll"; DestDir: "{app}"; Flags: ignoreversion
 
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 

--- a/ProjectsTM.Logic/KeyState.cs
+++ b/ProjectsTM.Logic/KeyState.cs
@@ -5,5 +5,6 @@ namespace ProjectsTM.Logic
     public static class KeyState
     {
         public static bool IsControlDown => (Control.ModifierKeys & Keys.Control) == Keys.Control;
+        public static bool IsShiftDown => (Control.ModifierKeys & Keys.Shift) == Keys.Shift;
     }
 }

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -140,14 +140,7 @@ namespace ProjectsTM.UI.TaskList
                 HandleSortRequest(rawLocation);
                 return;
             }
-
-            if (KeyState.IsShiftDown) { SelectItems(r); return; }
-
-            var item = _listItems[r.Value - FixedRowCount];
-            if (!item.IsMilestone)
-            {
-                _viewData.Selected = new WorkItems(item.WorkItem);
-            }
+            SelectItems(r);
         }
 
         private void HandleSortRequest(RawPoint rawLocation)

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -10,6 +10,7 @@ using System.Drawing;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
+using System.Text;
 
 namespace ProjectsTM.UI.TaskList
 {
@@ -65,30 +66,30 @@ namespace ProjectsTM.UI.TaskList
             }
         }
 
-        private string CreateStringOneLine(WorkItem w)
+        private void SetStrOneLine(StringBuilder copyData, WorkItem  w)
         {
             const string DOUBLE_Q = "\"";
             const string TAB = "\t";
-            string copyData = w.Name.ToString() + TAB
-                            + w.Project.ToString() + TAB
-                            + w.AssignedMember.ToString() + TAB
-                            + w.Tags.ToString() + TAB
-                            + w.State + TAB
-                            + w.Period.From.ToString() + TAB
-                            + w.Period.To + TAB
-                            + _viewData.Original.Callender.GetPeriodDayCount(w.Period).ToString() + TAB
-                            + DOUBLE_Q + w.Description + DOUBLE_Q + TAB;
-            copyData += Environment.NewLine;
-            return copyData;
+            copyData.Append(w.Name.ToString());             copyData.Append(TAB);
+            copyData.Append(w.Project.ToString());          copyData.Append(TAB);
+            copyData.Append(w.AssignedMember.ToString());   copyData.Append(TAB);
+            copyData.Append(w.Tags.ToString());             copyData.Append(TAB);
+            copyData.Append(w.State);                       copyData.Append(TAB);
+            copyData.Append(w.Period.From.ToString());      copyData.Append(TAB);
+            copyData.Append(w.Period.To.ToString());        copyData.Append(TAB);
+            copyData.Append(_viewData.Original.Callender.GetPeriodDayCount(w.Period).ToString());
+                                                            copyData.Append(TAB);
+            copyData.Append(DOUBLE_Q); copyData.Append(w.Description); copyData.Append(DOUBLE_Q);
+                                                            copyData.AppendLine(TAB);
         }
 
         private void CopyToClipboard()
         {
             if (_viewData.Selected == null) return;
             var workItems = _viewData.Selected;
-            string copyData = string.Empty;
-            foreach (var w in workItems) { copyData += CreateStringOneLine(w); }          
-            Clipboard.SetData(DataFormats.Text, copyData);
+            StringBuilder copyData = new StringBuilder(string.Empty);
+            foreach (var w in workItems) { SetStrOneLine(copyData, w); }
+            Clipboard.SetData(DataFormats.Text, copyData.ToString());
         }
 
         private void MoveSelect(int offset)

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -101,7 +101,6 @@ namespace ProjectsTM.UI.TaskList
             var to = r.Value - FixedRowCount;
             if (IsMultiSelect()) from = _lastSelect.Value - FixedRowCount;
             SelectRange(from, to);
-            return;
         }
 
         private bool IsMultiSelect()

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -24,7 +24,7 @@ namespace ProjectsTM.UI.TaskList
         private ColIndex _sortCol = new ColIndex(6);
         private bool _isReverse = false;
         private RowIndex _clickedRawIndexBefore;
-        private bool IsShiftKeyDown { get; set; }
+        private bool _isShiftKeyDown;
 
         public TaskListGrid()
         {
@@ -41,7 +41,7 @@ namespace ProjectsTM.UI.TaskList
         {
             if (e.KeyCode == Keys.ShiftKey)
             {
-                IsShiftKeyDown = false;
+                _isShiftKeyDown = false;
             }
         }
 
@@ -56,7 +56,7 @@ namespace ProjectsTM.UI.TaskList
                 MoveSelect(-1);
             }else if(e.KeyCode == Keys.ShiftKey)
             {
-                IsShiftKeyDown = true;
+                _isShiftKeyDown = true;
             }
         }
 
@@ -136,7 +136,7 @@ namespace ProjectsTM.UI.TaskList
                 return;
             }
 
-            if (IsShiftKeyDown) { TaskListGrid_MouseClickAndShiftKey(r); return; }
+            if (_isShiftKeyDown) { TaskListGrid_MouseClickAndShiftKey(r); return; }
 
             var item = _listItems[r.Value - FixedRowCount];
             if (!item.IsMilestone)
@@ -246,7 +246,7 @@ namespace ProjectsTM.UI.TaskList
             if (_viewData.Selected == null || _viewData.Selected.Count() == 0) { _clickedRawIndexBefore = null; return; }
             if (_viewData.Selected.Count() > 1)
             {
-                if (!IsShiftKeyDown) _clickedRawIndexBefore = null;
+                if (!_isShiftKeyDown) _clickedRawIndexBefore = null;
                 return;
             }
             var idx = _listItems.FindIndex(l => l.WorkItem.Equals(_viewData.Selected.Unique));

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -54,10 +54,41 @@ namespace ProjectsTM.UI.TaskList
             else if (e.KeyCode == Keys.Up)
             {
                 MoveSelect(-1);
-            }else if(e.KeyCode == Keys.ShiftKey)
+            }
+            else if(e.KeyCode == Keys.ShiftKey)
             {
                 _isShiftKeyDown = true;
             }
+            else if(e.Control && (e.KeyCode == Keys.C))
+            {
+                CopyToClipboard();
+            }
+        }
+
+        private string CreateStringOneLine(WorkItem w)
+        {
+            const string DOUBLE_Q = "\"";
+            const string TAB = "\t";
+            string copyData = w.Name.ToString() + TAB
+                            + w.Project.ToString() + TAB
+                            + w.AssignedMember.ToString() + TAB
+                            + w.Tags.ToString() + TAB
+                            + w.State + TAB
+                            + w.Period.From.ToString() + TAB
+                            + w.Period.To + TAB
+                            + _viewData.Original.Callender.GetPeriodDayCount(w.Period).ToString() + TAB
+                            + DOUBLE_Q + w.Description + DOUBLE_Q + TAB;
+            copyData += Environment.NewLine;
+            return copyData;
+        }
+
+        private void CopyToClipboard()
+        {
+            if (_viewData.Selected == null) return;
+            var workItems = _viewData.Selected;
+            string copyData = string.Empty;
+            foreach (var w in workItems) { copyData += CreateStringOneLine(w); }          
+            Clipboard.SetData(DataFormats.Text, copyData);
         }
 
         private void MoveSelect(int offset)

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -88,7 +88,7 @@ namespace ProjectsTM.UI.TaskList
         private List<TaskListItem> GetMultiSelectedTaskListItems(int minRowIndex, int maxRowIndex)
         {
             List<TaskListItem> items = new List<TaskListItem>();
-            if (CheckMultiRowIndex(minRowIndex, maxRowIndex)) return items;
+            if (!CheckMultiRowIndex(minRowIndex, maxRowIndex)) return items;
 
             for (var idx = minRowIndex; idx <= maxRowIndex; idx++)
             {

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -25,7 +25,6 @@ namespace ProjectsTM.UI.TaskList
         private ColIndex _sortCol = new ColIndex(6);
         private bool _isReverse = false;
         private RowIndex _clickedRawIndexBefore;
-        private bool _isShiftKeyDown;
 
         public TaskListGrid()
         {
@@ -35,15 +34,6 @@ namespace ProjectsTM.UI.TaskList
             this.MouseClick += TaskListGrid_MouseClick;
             this.Disposed += TaskListGrid_Disposed;
             this.KeyDown += TaskListGrid_KeyDown;
-            this.KeyUp += TaskListGrid_KeyUp;
-        }
-
-        private void TaskListGrid_KeyUp(object sender, KeyEventArgs e)
-        {
-            if (e.KeyCode == Keys.ShiftKey)
-            {
-                _isShiftKeyDown = false;
-            }
         }
 
         private void TaskListGrid_KeyDown(object sender, KeyEventArgs e)
@@ -56,11 +46,7 @@ namespace ProjectsTM.UI.TaskList
             {
                 MoveSelect(-1);
             }
-            else if(e.KeyCode == Keys.ShiftKey)
-            {
-                _isShiftKeyDown = true;
-            }
-            else if(e.Control && (e.KeyCode == Keys.C))
+            else if(KeyState.IsControlDown && (e.KeyCode == Keys.C))
             {
                 CopyToClipboard();
             }
@@ -168,7 +154,7 @@ namespace ProjectsTM.UI.TaskList
                 return;
             }
 
-            if (_isShiftKeyDown) { TaskListGrid_MouseClickAndShiftKey(r); return; }
+            if (KeyState.IsShiftDown) { TaskListGrid_MouseClickAndShiftKey(r); return; }
 
             var item = _listItems[r.Value - FixedRowCount];
             if (!item.IsMilestone)
@@ -278,7 +264,7 @@ namespace ProjectsTM.UI.TaskList
             if (_viewData.Selected == null || _viewData.Selected.Count() == 0) { _clickedRawIndexBefore = null; return; }
             if (_viewData.Selected.Count() > 1)
             {
-                if (!_isShiftKeyDown) _clickedRawIndexBefore = null;
+                if (!KeyState.IsShiftDown) _clickedRawIndexBefore = null;
                 return;
             }
             var idx = _listItems.FindIndex(l => l.WorkItem.Equals(_viewData.Selected.Unique));

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -24,7 +24,7 @@ namespace ProjectsTM.UI.TaskList
         private ColIndex _sortCol = new ColIndex(6);
         private bool _isReverse = false;
         private RowIndex _clickedRawIndexBefore;
-        private bool isShiftKeyDown;
+        private bool IsShiftKeyDown { get; set; }
 
         public TaskListGrid()
         {
@@ -41,7 +41,7 @@ namespace ProjectsTM.UI.TaskList
         {
             if (e.KeyCode == Keys.ShiftKey)
             {
-                isShiftKeyDown = false;
+                IsShiftKeyDown = false;
             }
         }
 
@@ -56,7 +56,7 @@ namespace ProjectsTM.UI.TaskList
                 MoveSelect(-1);
             }else if(e.KeyCode == Keys.ShiftKey)
             {
-                isShiftKeyDown = true;
+                IsShiftKeyDown = true;
             }
         }
 
@@ -136,7 +136,7 @@ namespace ProjectsTM.UI.TaskList
                 return;
             }
 
-            if (isShiftKeyDown) { TaskListGrid_MouseClickAndShiftKey(r); return; }
+            if (IsShiftKeyDown) { TaskListGrid_MouseClickAndShiftKey(r); return; }
 
             var item = _listItems[r.Value - FixedRowCount];
             if (!item.IsMilestone)
@@ -246,7 +246,7 @@ namespace ProjectsTM.UI.TaskList
             if (_viewData.Selected == null || _viewData.Selected.Count() == 0) { _clickedRawIndexBefore = null; return; }
             if (_viewData.Selected.Count() > 1)
             {
-                if (!isShiftKeyDown) _clickedRawIndexBefore = null;
+                if (!IsShiftKeyDown) _clickedRawIndexBefore = null;
                 return;
             }
             var idx = _listItems.FindIndex(l => l.WorkItem.Equals(_viewData.Selected.Unique));


### PR DESCRIPTION
※　プロジェクト構成リファクタブランチへのPRです。
■　タスクリスト上検索結果のコピペのために、タスクリスト項目を複数選択できるよう変更。

・前回選択された行数を覚えるメンバを追加
・シフトキーが押されたことを検出するイベントを追加
・シフトキー押されながら項目クリックしたときは、
　前回選択項目から、現在選択項目の間の項目すべてを_viewData.Selectedに追加するよう変更