### PR TITLE
タスクリストの選択描画が遅い問題の修正

### DIFF
--- a/FreeGridControl/GridControl.cs
+++ b/FreeGridControl/GridControl.cs
@@ -73,7 +73,6 @@ namespace FreeGridControl
                 var targetWidth = _cache.GetLeft(col.Offset(1)) - _cache.FixedWidth;
                 this.hScrollBar.Value = (int)((targetWidth / (float)_cache.GridWidth) * (this.hScrollBar.Maximum - this.hScrollBar.LargeChange));
             }
-            Thread.Sleep(250);
         }
 
         private bool IsVisibleRange(RowIndex row, int count, ColIndex col)


### PR DESCRIPTION
_viewData.Selectが変更されると、WorkItemGridとTaskGridの再描画が行われるが、
その際に走る
WorkItemGrid.MoveVisibleRowCol(RowIndex row, ColIndex col)　内の
Thread.Sleep(250);が効いていた。

このThread.Sleep(250);は、グリッド外ドラッグによる高速移動を抑制するためのWaitであったが、
その対策によって失っているもの方が大きいので、対策をやめる。
タスクリストの選択描画改善を優先する。