### PR TITLE
git fetchをバックグラウンド実行して未マージの変更があることをタイトルバーにて通知

### DIFF
--- a/ProjectsTM.Service/AppDataFileIOService.cs
+++ b/ProjectsTM.Service/AppDataFileIOService.cs
@@ -12,11 +12,13 @@ namespace ProjectsTM.Service
         public event EventHandler<string> FileOpened;
         public event EventHandler FileSaved;
         private DateTime _last;
+        private GitRepositoryService _gitRepositoryService;
 
-        public AppDataFileIOService()
+        public AppDataFileIOService(GitRepositoryService gitRepositoryService)
         {
             _watcher = new FileSystemWatcher();
             _watcher.Changed += _watcher_Changed;
+            _gitRepositoryService = gitRepositoryService;
         }
 
         private void _watcher_Changed(object sender, FileSystemEventArgs e)
@@ -122,7 +124,14 @@ namespace ProjectsTM.Service
             _watcher.IncludeSubdirectories = false;
             _watcher.EnableRaisingEvents = true;
             FileOpened?.Invoke(this, fileName);
+            CheckRemoteBranchAppData(fileName);
             return AppDataSerializeService.Deserialize(fileName);
+        }
+
+        private void CheckRemoteBranchAppData(string filePath)
+        {
+            _gitRepositoryService.IsRemoteBranchAppDataNew = false;
+            _gitRepositoryService.CheckRemoteBranchAppDataFile(filePath);
         }
 
         private bool IsFutureVersion(string fileName)

--- a/ProjectsTM.Service/GitCmd.cs
+++ b/ProjectsTM.Service/GitCmd.cs
@@ -1,0 +1,72 @@
+﻿using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace ProjectsTM.Service
+{
+    class GitCmd
+    {
+        internal static void GitFetch(string filePath)
+        {
+            var gitRepoPath = SearchGitRepo(filePath);
+            if (string.IsNullOrEmpty(gitRepoPath) || string.IsNullOrEmpty(filePath)) return;
+            GitCmdCommon.gitCommand("-C " + gitRepoPath + " fetch");
+        }
+ 
+        private static string GetCurrentBranchName()
+        {
+            StringReader reader = new StringReader(GitCmdCommon.gitCommand("rev-parse --abbrev-ref Head"));
+            return reader.ReadLine();
+        }
+
+        internal static int GetLocalBranchDate(string filePath)
+        {
+            var gitRepoPath = SearchGitRepo(filePath);
+            if (string.IsNullOrEmpty(gitRepoPath) || string.IsNullOrEmpty(filePath)) return -1;
+            return ParseDate(GitCmdCommon.gitCommand("-C " + gitRepoPath + " log -1 --date=short --pretty=format:%cd -- " + filePath));
+        }
+
+        internal static int GetRemoteBranchDate(string filePath)
+        {
+            var gitRepoPath = SearchGitRepo(filePath);
+            if (string.IsNullOrEmpty(gitRepoPath) || string.IsNullOrEmpty(filePath)) return -1;
+            return ParseDate(GitCmdCommon.gitCommand("-C " + gitRepoPath + " log -1 remotes/origin/" + GetCurrentBranchName() + " --date=short --pretty=format:%cd -- " + filePath));
+        }
+
+        internal static int GetLocalBranchCommitTime(string filePath)
+        {
+            var gitRepoPath = SearchGitRepo(filePath);
+            if (string.IsNullOrEmpty(gitRepoPath) || string.IsNullOrEmpty(filePath)) return -1;
+            return ParseTime(GitCmdCommon.gitCommand("-C " + gitRepoPath + " log -1 --pretty=format:%cd -- " + filePath));
+        }
+
+        internal static int GetRemoteBranchCommitTime(string filePath)
+        {
+            var gitRepoPath = SearchGitRepo(filePath);
+            if (string.IsNullOrEmpty(gitRepoPath) || string.IsNullOrEmpty(filePath)) return -1;
+            return ParseTime(GitCmdCommon.gitCommand("-C " + gitRepoPath + " log -1 remotes/origin/" + GetCurrentBranchName() + " --pretty=format:%cd -- " + filePath));
+        }
+
+        private static int ParseDate(string output)
+        {
+            var m = Regex.Match(output, @"(\d)(\d)(\d)(\d)-(\d)(\d)-(\d)(\d)");
+            if (!m.Success) return -1;
+            return int.Parse(m.Value.Replace("-", ""));
+        }
+
+        private static int ParseTime(string output)
+        {
+            var m = Regex.Match(output, @"(\d)(\d):(\d)(\d):(\d)(\d)");
+            if (!m.Success) return -1;
+            return int.Parse(m.Value.Replace(":", ""));
+        }
+
+        internal static string SearchGitRepo(string path)
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (dir == null) return string.Empty;
+            var repositoryPath = Directory.GetDirectories(dir, ".git");
+            return repositoryPath.Count() == 0 ? SearchGitRepo(dir) : Path.GetDirectoryName(repositoryPath[0]);
+        }
+    }
+}

--- a/ProjectsTM.Service/GitCmdCommon.cs
+++ b/ProjectsTM.Service/GitCmdCommon.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace ProjectsTM.Service
+{
+    class GitCmdCommon
+    {
+        internal static int executeCommand(out string output, string command, string arguments = "")
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo(command)
+                {
+                    Arguments = arguments,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            };
+            process.Start();
+            process.WaitForExit();
+            output = process.StandardOutput.ReadToEnd();
+            return process.ExitCode;
+        }
+
+        internal static string gitCommand(string arguments)
+        {
+            string output;
+            if (executeCommand(out output, "git", arguments) != 0)
+            {
+                throw new Exception("git command error");
+            }
+            return output;
+        }
+    }
+}

--- a/ProjectsTM.Service/GitRepositoryService.cs
+++ b/ProjectsTM.Service/GitRepositoryService.cs
@@ -25,16 +25,15 @@ namespace ProjectsTM.Service
 
         internal void CheckRemoteBranchAppDataFile(string filePath)
         {
-            Task<bool> task = Task.Run(() =>
+            Task task = Task.Run(() =>
             {
                 GitCmd.GitFetch(filePath);
                 if (DoesRemoteBranchHaveNewCommit(filePath))
                 {
                     IsRemoteBranchAppDataNew = true;
-                    return true;
+                    return;
                 }
                 IsRemoteBranchAppDataNew = false;
-                return false;
             });
         }    
 

--- a/ProjectsTM.Service/GitRepositoryService.cs
+++ b/ProjectsTM.Service/GitRepositoryService.cs
@@ -41,8 +41,9 @@ namespace ProjectsTM.Service
         private bool DoesRemoteBranchHaveNewCommit(string filePath)
         {
             var localBranchDate = GitCmd.GetLocalBranchDate(filePath);
+            if (localBranchDate <= 0) return false;
             var remoteBranchDate = GitCmd.GetRemoteBranchDate(filePath);
-            if (localBranchDate <= 0 || remoteBranchDate <= 0) return false;
+            if (remoteBranchDate <= 0) return false;
             if (localBranchDate == remoteBranchDate) return IsRemoteBranchTimeStampNew(filePath);
             return remoteBranchDate > localBranchDate;
         }
@@ -50,8 +51,9 @@ namespace ProjectsTM.Service
         private bool IsRemoteBranchTimeStampNew(string filePath)
         {
             var localCommitTime = GitCmd.GetLocalBranchCommitTime(filePath);
-            var remoteCommitTime = GitCmd.GetRemoteBranchCommitTime(filePath);
-            if (localCommitTime <= 0 || remoteCommitTime <= 0) return false;
+            if (localCommitTime <= 0) return false;
+                var remoteCommitTime = GitCmd.GetRemoteBranchCommitTime(filePath);
+            if (remoteCommitTime <= 0) return false;
             return remoteCommitTime > localCommitTime;
         }
     }

--- a/ProjectsTM.Service/GitRepositoryService.cs
+++ b/ProjectsTM.Service/GitRepositoryService.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace ProjectsTM.Service
+{
+    public class GitRepositoryService
+    {
+        private bool _isRemoteBranchAppDataNew = false;
+        private Action<bool> _UpdateMainFormTitlebarText;
+
+        public GitRepositoryService(Action<bool> UpdateMainFormText)
+        {
+            _UpdateMainFormTitlebarText = UpdateMainFormText;
+        }
+
+        public bool IsRemoteBranchAppDataNew
+        {
+            get { return _isRemoteBranchAppDataNew; }
+            set
+            {
+                _isRemoteBranchAppDataNew = value;
+                _UpdateMainFormTitlebarText?.Invoke(_isRemoteBranchAppDataNew);
+            }
+        }
+
+        internal void CheckRemoteBranchAppDataFile(string filePath)
+        {
+            Task<bool> task = Task.Run(() =>
+            {
+                GitCmd.GitFetch(filePath);
+                if (DoesRemoteBranchHaveNewCommit(filePath))
+                {
+                    IsRemoteBranchAppDataNew = true;
+                    return true;
+                }
+                IsRemoteBranchAppDataNew = false;
+                return false;
+            });
+        }    
+
+        private bool DoesRemoteBranchHaveNewCommit(string filePath)
+        {
+            var localBranchDate = GitCmd.GetLocalBranchDate(filePath);
+            var remoteBranchDate = GitCmd.GetRemoteBranchDate(filePath);
+            if (localBranchDate <= 0 || remoteBranchDate <= 0) return false;
+            if (localBranchDate == remoteBranchDate) return IsRemoteBranchTimeStampNew(filePath);
+            return remoteBranchDate > localBranchDate;
+        }
+
+        private bool IsRemoteBranchTimeStampNew(string filePath)
+        {
+            var localCommitTime = GitCmd.GetLocalBranchCommitTime(filePath);
+            var remoteCommitTime = GitCmd.GetRemoteBranchCommitTime(filePath);
+            if (localCommitTime <= 0 || remoteCommitTime <= 0) return false;
+            return remoteCommitTime > localCommitTime;
+        }
+    }
+}

--- a/ProjectsTM.Service/ProjectsTM.Service.csproj
+++ b/ProjectsTM.Service/ProjectsTM.Service.csproj
@@ -58,6 +58,9 @@
     <Compile Include="EditedEventArgs.cs" />
     <Compile Include="FileDragService.cs" />
     <Compile Include="FilterComboBoxService.cs" />
+    <Compile Include="GitCmdCommon.cs" />
+    <Compile Include="GitCmd.cs" />
+    <Compile Include="GitRepositoryService.cs" />
     <Compile Include="KeyAndMouseHandleService.cs" />
     <Compile Include="OldFileService.cs" />
     <Compile Include="OverwrapedWorkItemsCollectService.cs" />

--- a/ProjectsTM.UI.MainForm/MainForm.cs
+++ b/ProjectsTM.UI.MainForm/MainForm.cs
@@ -28,6 +28,7 @@ namespace ProjectsTM.UI.MainForm
         private PatternHistory _patternHistory = new PatternHistory();
         private FormSize _formSize = new FormSize();
         private GitRepositoryService _gitRepositoryService;
+
         public MainForm()
         {
             InitializeComponent();
@@ -130,7 +131,7 @@ namespace ProjectsTM.UI.MainForm
         }
 
         private static string UserSettingPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ProjectsTM", "UserSetting.xml");
-        
+
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
             if (!_isDirty) return;

--- a/ProjectsTM.UI.MainForm/MainForm.cs
+++ b/ProjectsTM.UI.MainForm/MainForm.cs
@@ -27,13 +27,14 @@ namespace ProjectsTM.UI.MainForm
         private bool _isDirty = false;
         private PatternHistory _patternHistory = new PatternHistory();
         private FormSize _formSize = new FormSize();
-
+        private GitRepositoryService _gitRepositoryService;
         public MainForm()
         {
             InitializeComponent();
             menuStrip1.ImageScalingSize = new Size(16, 16);
             PrintService = new PrintService(_viewData, workItemGrid1.Font, Print);
-            FileIOService = new AppDataFileIOService();
+            _gitRepositoryService = new GitRepositoryService(this.UpdateTitlebarText);
+            FileIOService = new AppDataFileIOService(_gitRepositoryService);
             _filterComboBoxService = new FilterComboBoxService(_viewData, toolStripComboBoxFilter, IsMemberMatchText);
             _contextMenuService = new ContextMenuHandler(_viewData, workItemGrid1);
             statusStrip1.Items.Add("");
@@ -51,6 +52,17 @@ namespace ProjectsTM.UI.MainForm
             workItemGrid1.HoveringTextChanged += WorkItemGrid1_HoveringTextChanged;
             toolStripStatusLabelViewRatio.Text = "拡大率:" + _viewData.Detail.ViewRatio.ToString();
             workItemGrid1.RatioChanged += WorkItemGrid1_RatioChanged;
+        }
+
+        private void UpdateTitlebarText(bool _isRemoteBranchAppDataNew)
+        {
+            if (this.InvokeRequired) { this.Invoke(new Action(() => UpdateTitlebarText(_isRemoteBranchAppDataNew))); return; }
+            if (_isRemoteBranchAppDataNew)
+            {
+                this.Text = "ProjectsTM     ***リモートブランチのデータに更新があります***";
+                return;
+            }
+            this.Text = "ProjectsTM";
         }
 
         private void Print(PrintPageEventArgs e)
@@ -118,7 +130,7 @@ namespace ProjectsTM.UI.MainForm
         }
 
         private static string UserSettingPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ProjectsTM", "UserSetting.xml");
-
+        
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
             if (!_isDirty) return;


### PR DESCRIPTION
概要：AppDataファイルオープン時に開くファイルをフェッチして、新しいコミットがあればタイトルバーで通知するよう追加。

AppDataファイルオープン時にバックグラウンドで
・対象ファイルをフェッチする
・ローカルブランチとリモートブランチの対象ファイルの最新コミット日付を比較する。
　同じ日付であれば、タイムスタンプを比較する。
・リモートブランチに新しいコミットがあれば、MainFormタイトルで通知する。