### PR TITLE
AppDataをファイル出力時に、メンバー内タスクをPeriod.fromでソートするよう追加。（AppDataファイルのマージ簡易にするため）

### DIFF
--- a/ProjectsTM.Model/MembersWorkItems.cs
+++ b/ProjectsTM.Model/MembersWorkItems.cs
@@ -63,5 +63,10 @@ namespace ProjectsTM.Model
         {
             return -566117206 + EqualityComparer<List<WorkItem>>.Default.GetHashCode(_items);
         }
+
+        public void SortByPeriodStartDate()
+        {
+            _items.Sort((a, b) => a.Period.From.CompareTo(b.Period.From));
+        }
     }
 }

--- a/ProjectsTM.Model/WorkItems.cs
+++ b/ProjectsTM.Model/WorkItems.cs
@@ -109,5 +109,13 @@ namespace ProjectsTM.Model
             }
             return result;
         }
+
+        public void SortByPeriodStartDate()
+        {
+            foreach (var workItems in this.EachMembers)
+            {
+                workItems.SortByPeriodStartDate();
+            }
+        }
     }
 }

--- a/ProjectsTM.Service/AppDataFileIOService.cs
+++ b/ProjectsTM.Service/AppDataFileIOService.cs
@@ -49,6 +49,7 @@ namespace ProjectsTM.Service
             _watcher.EnableRaisingEvents = false;
             try
             {
+                appData.WorkItems.SortByPeriodStartDate();
                 AppDataSerializeService.Serialize(_previousFileName, appData);
                 FileSaved?.Invoke(this, null);
             }
@@ -68,6 +69,7 @@ namespace ProjectsTM.Service
                 _watcher.EnableRaisingEvents = false;
                 try
                 {
+                    appData.WorkItems.SortByPeriodStartDate();
                     AppDataSerializeService.Serialize(dlg.FileName, appData);
                     FileSaved?.Invoke(this, null);
                     _previousFileName = dlg.FileName;


### PR DESCRIPTION
■問題
WorkItemが編集されると（編集前Itemは削除して）新しいWorkItemが追加される設計のため、
AppDataファイル上ではMemberごとのWorkItemsの最後尾にworkItemが追加されることになり、
マージ時に適切な差分検出ができず、非編集箇所の変更差分が多く検出される。

■対策
AppDataファイル出力時にMemberごとのWorkItemsをPeriod.Fromでソートすることで、
マージ検出時に非編集箇所が検出されることを抑制する。
