### PR TITLE
タスクリスト表示しながらのWorkItemGridドラッグが遅い問題の対策

### DIFF
--- a/ProjectsTM.Service/WorkItemDragService.cs
+++ b/ProjectsTM.Service/WorkItemDragService.cs
@@ -18,6 +18,7 @@ namespace ProjectsTM.Service
         private RawPoint _draggedLocation;
         private CallenderDay _draggedDay = null;
         private int _expandDirection = 0;
+        public event EventHandler<List<WorkItems>> ApplyEditDone;
 
         private DragState _state = DragState.None;
         public DragState State
@@ -275,6 +276,15 @@ namespace ProjectsTM.Service
                     break;
             }
             viewData.Selected = edit;
+            ApplyEditToTaskList(_backup, edit);
+        }
+
+        private void ApplyEditToTaskList(WorkItems before, WorkItems after) 
+        {
+            var workItemsBeforeAndAfter = new List<WorkItems>();
+            workItemsBeforeAndAfter.Add(before);
+            workItemsBeforeAndAfter.Add(after);
+            ApplyEditDone?.Invoke(null, workItemsBeforeAndAfter);
         }
 
         private void ClearEdit(ViewData viewData)

--- a/ProjectsTM.UI.MainForm/MainForm.cs
+++ b/ProjectsTM.UI.MainForm/MainForm.cs
@@ -49,8 +49,14 @@ namespace ProjectsTM.UI.MainForm
             workItemGrid1.Initialize(_viewData);
             workItemGrid1.UndoChanged += _undoService_Changed;
             workItemGrid1.HoveringTextChanged += WorkItemGrid1_HoveringTextChanged;
+            workItemGrid1.DragEditDone += WorkItemGrid1_DragEditDone;
             toolStripStatusLabelViewRatio.Text = "拡大率:" + _viewData.Detail.ViewRatio.ToString();
             workItemGrid1.RatioChanged += WorkItemGrid1_RatioChanged;
+        }
+
+        private void WorkItemGrid1_DragEditDone(object sender, List<WorkItems> workitemsBeforeAndAfter)
+        {
+            TaskListForm?.DragEditDone(workitemsBeforeAndAfter[0], workitemsBeforeAndAfter[1]);
         }
 
         private void Print(PrintPageEventArgs e)
@@ -391,7 +397,8 @@ namespace ProjectsTM.UI.MainForm
         {
             if (TaskListForm == null || TaskListForm.IsDisposed)
             {
-                TaskListForm = new TaskListForm(_viewData, _patternHistory, _formSize);
+                TaskListForm = new TaskListForm(_viewData, _patternHistory, _formSize, workItemGrid1.IsDragActive);
+
             }
             if (!TaskListForm.Visible) TaskListForm.Show(this);
         }

--- a/ProjectsTM.UI.MainForm/WorkItemGrid.cs
+++ b/ProjectsTM.UI.MainForm/WorkItemGrid.cs
@@ -33,6 +33,8 @@ namespace ProjectsTM.UI
         public event EventHandler<IEditedEventArgs> UndoChanged;
         public event EventHandler<float> RatioChanged;
         public event EventHandler<WorkItem> HoveringTextChanged;
+        public event EventHandler<List<WorkItems>> DragEditDone;
+
         public WorkItemGrid() { }
 
         internal void Initialize(ViewData viewData)
@@ -49,6 +51,7 @@ namespace ProjectsTM.UI
             if (_keyAndMouseHandleService != null) _keyAndMouseHandleService.Dispose();
             _keyAndMouseHandleService = new KeyAndMouseHandleService(_viewData, this, _workItemDragService, _drawService, _editService, this);
             _keyAndMouseHandleService.HoveringTextChanged += _keyAndMouseHandleService_HoveringTextChanged;
+            _workItemDragService.ApplyEditDone += _workItemDragService_ApplyEditDone;
             ApplyDetailSetting();
             _editService = new WorkItemEditService(_viewData);
             LockUpdate = false;
@@ -58,6 +61,11 @@ namespace ProjectsTM.UI
                 this,
                 () => _workItemDragService.IsActive(),
                 this.Font);
+        }
+
+        private void _workItemDragService_ApplyEditDone(object sender, List<WorkItems> workitemsBeforeAndAfter)
+        {
+            DragEditDone?.Invoke(null, workitemsBeforeAndAfter);
         }
 
         private void _keyAndMouseHandleService_HoveringTextChanged(object sender, WorkItem e)
@@ -400,5 +408,7 @@ namespace ProjectsTM.UI
             if (m == null || d == null) return null;
             return _viewData.PickFilterdWorkItem(m, d);
         }
+
+        public bool IsDragActive() { return _workItemDragService.IsActive(); }
     }
 }

--- a/ProjectsTM.UI.TaskList/TaskListForm.cs
+++ b/ProjectsTM.UI.TaskList/TaskListForm.cs
@@ -11,15 +11,17 @@ namespace ProjectsTM.UI.TaskList
         private readonly ViewData _viewData;
         private PatternHistory _history;
         private FormSize _formSize;
+        private readonly Func<bool> _IsWorkItemGridDragActive;
 
-        public TaskListForm(ViewData viewData, PatternHistory patternHistory, FormSize formSize)
+        public TaskListForm(ViewData viewData, PatternHistory patternHistory, FormSize formSize, Func<bool> IsWorkItemGridDragActive)
         {
             InitializeComponent();
 
             this._viewData = viewData;
             this._history = patternHistory;
+            this._IsWorkItemGridDragActive = IsWorkItemGridDragActive;
             gridControl1.ListUpdated += GridControl1_ListUpdated;
-            gridControl1.Initialize(viewData, comboBoxPattern.Text);
+            gridControl1.Initialize(viewData, comboBoxPattern.Text, _IsWorkItemGridDragActive);
             var offset = gridControl1.GridWidth - gridControl1.Width;
             this.Width += offset + gridControl1.VScrollBarWidth;
             this.Height = formSize?.TaskListFormHeight > this.Height ? formSize.TaskListFormHeight : this.Height;
@@ -47,7 +49,7 @@ namespace ProjectsTM.UI.TaskList
 
         public void Clear()
         {
-            gridControl1.Initialize(_viewData, comboBoxPattern.Text);
+            gridControl1.Initialize(_viewData, comboBoxPattern.Text, _IsWorkItemGridDragActive);
         }
 
         private void comboBoxPattern_DropDown(object sender, System.EventArgs e)
@@ -64,7 +66,12 @@ namespace ProjectsTM.UI.TaskList
         private void UpdateList()
         {
             _history.Append(comboBoxPattern.Text);
-            gridControl1.Initialize(_viewData, comboBoxPattern.Text);
+            gridControl1.Initialize(_viewData, comboBoxPattern.Text, _IsWorkItemGridDragActive);
+        }
+
+        public void DragEditDone(WorkItems before, WorkItems after)
+        {
+            gridControl1.DragEditDone(before, after);
         }
 
     }

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -256,6 +256,7 @@ namespace ProjectsTM.UI.TaskList
                 _listItems[listIdx] = new TaskListItem(after.ElementAt(i), item.Color, item.IsMilestone, item.ErrMsg);
             }
             Sort();
+            ListUpdated?.Invoke(this, null);
         }
 
         internal void DragEditDone(WorkItems before, WorkItems after) 

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -67,9 +67,9 @@ namespace ProjectsTM.UI.TaskList
             copyData.Append(w.Period.From.ToString());      copyData.Append(TAB);
             copyData.Append(w.Period.To.ToString());        copyData.Append(TAB);
             copyData.Append(_viewData.Original.Callender.GetPeriodDayCount(w.Period).ToString());
-            copyData.Append(TAB);
+                                                            copyData.Append(TAB);
             copyData.Append(DOUBLE_Q); copyData.Append(w.Description); copyData.Append(DOUBLE_Q);
-            copyData.AppendLine(TAB);
+                                                            copyData.AppendLine(TAB);
         }
 
         private void CopyToClipboard()


### PR DESCRIPTION
タスクリストのパフォーマンス改善。
※users/matsukage/tasklist_performanceへのPRです。
　目的が異なり、どちらの目的のためのコードかわかりにくくなるのでPR分けました。
　変更箇所が被っているので競合を避けるために、masterでなく上記ブランチへマージします。

■遅い原因
WorkItemGridドラッグ時はドラッグ位置に合わせてViewData.Selectedが更新され続け、
ViewData.Selected更新イベントによってタスクリストのInitializeGrid（）が繰り返し走ることが遅い原因。

■対策①
WorkItemGridドラッグ時のViewData.Selected更新イベント起因では、タスクリストの更新を行わない。
（WorkItemDragService.IsActive()がTRUEの場合は、更新しない。）
代わりに、WorkItemGridドラッグ完了時に発火するイベント（ApplyEditDone）を追加し、
ドラッグ完了時のみドラッグによる編集内容をタスクリストへ反映する。

■対策②
ドラッグによる編集内容をタスクリストへ反映する際は、InitializeGrid（）を走らせない。
代わりに、TaskListGrid._listItemsGrid._listItemsからドラッグ編集対象を検索し、対象のみ更新する。

対策②は横展開できる内容であるが、横展開はこのプルリクに含まず、後日展開する。
（例えばAuditServiceの結果マージはInitializeGrid()で反映する必要なく、対策②と同様にできる）


