### PR TITLE
【再】タスクリスト表示しながらのWorkItemGridドラッグが遅い問題の対策

### DIFF
--- a/ProjectsTM.Service/OverwrapedWorkItemsCollectService.cs
+++ b/ProjectsTM.Service/OverwrapedWorkItemsCollectService.cs
@@ -6,6 +6,20 @@ namespace ProjectsTM.Service
 {
     public static class OverwrapedWorkItemsCollectService
     {
+        public static List<WorkItem> Get(WorkItem target, WorkItems workItems)
+        {
+            var result = new List<WorkItem>();
+            var workItemsOfMember = workItems.OfMember(target.AssignedMember);
+            foreach (var wi in workItemsOfMember)
+            {
+                if (!wi.Period.HasInterSection(target.Period)) continue;
+                if (wi.Equals(target)) continue;
+                result.Add(wi);
+                if (!result.Contains(target)) result.Add(target);
+            }
+            return result;
+        }
+
         public static List<WorkItem> Get(WorkItems workItems)
         {
             var result = new List<WorkItem>();

--- a/ProjectsTM.Service/WorkItemDragService.cs
+++ b/ProjectsTM.Service/WorkItemDragService.cs
@@ -18,6 +18,7 @@ namespace ProjectsTM.Service
         private RawPoint _draggedLocation;
         private CallenderDay _draggedDay = null;
         private int _expandDirection = 0;
+        public event EventHandler<DragDoneEventArgs> NotifyDragDone;
 
         private DragState _state = DragState.None;
         public DragState State
@@ -275,6 +276,12 @@ namespace ProjectsTM.Service
                     break;
             }
             viewData.Selected = edit;
+            NotifyApplyEditDone(_backup.Clone(), edit.Clone());
+        }
+
+        private void NotifyApplyEditDone(WorkItems before, WorkItems after)
+        {
+            NotifyDragDone?.Invoke(null, new DragDoneEventArgs(before, after));
         }
 
         private void ClearEdit(ViewData viewData)

--- a/ProjectsTM.UI.MainForm/MainForm.cs
+++ b/ProjectsTM.UI.MainForm/MainForm.cs
@@ -49,8 +49,14 @@ namespace ProjectsTM.UI.MainForm
             workItemGrid1.Initialize(_viewData);
             workItemGrid1.UndoChanged += _undoService_Changed;
             workItemGrid1.HoveringTextChanged += WorkItemGrid1_HoveringTextChanged;
+            workItemGrid1.NotifyDragEditDone += WorkItemGrid1_NotifyDragEditDone;
             toolStripStatusLabelViewRatio.Text = "拡大率:" + _viewData.Detail.ViewRatio.ToString();
             workItemGrid1.RatioChanged += WorkItemGrid1_RatioChanged;
+        }
+
+        private void WorkItemGrid1_NotifyDragEditDone(object sender, DragDoneEventArgs editedWorkItems)
+        {
+            TaskListForm?.ApplyEdit(editedWorkItems.Before, editedWorkItems.After);
         }
 
         private void UpdateTitlebarText(bool isRemoteBranchAppDataNew)
@@ -403,7 +409,7 @@ namespace ProjectsTM.UI.MainForm
         {
             if (TaskListForm == null || TaskListForm.IsDisposed)
             {
-                TaskListForm = new TaskListForm(_viewData, _patternHistory, _formSize);
+                TaskListForm = new TaskListForm(_viewData, _patternHistory, _formSize, workItemGrid1.IsDragActive);
             }
             if (!TaskListForm.Visible) TaskListForm.Show(this);
         }

--- a/ProjectsTM.UI.MainForm/WorkItemGrid.cs
+++ b/ProjectsTM.UI.MainForm/WorkItemGrid.cs
@@ -34,7 +34,17 @@ namespace ProjectsTM.UI.MainForm
         public event EventHandler<IEditedEventArgs> UndoChanged;
         public event EventHandler<float> RatioChanged;
         public event EventHandler<WorkItem> HoveringTextChanged;
-        public WorkItemGrid() { }
+        public event EventHandler<DragDoneEventArgs> NotifyDragEditDone;
+
+        public WorkItemGrid() 
+        {
+            _workItemDragService.NotifyDragDone += _workItemDragService_NotifyDragDone;
+        }
+
+        private void _workItemDragService_NotifyDragDone(object sender, DragDoneEventArgs editedWorkItems)
+        {
+            NotifyDragEditDone?.Invoke(null, editedWorkItems);
+        }
 
         internal void Initialize(ViewData viewData)
         {
@@ -401,5 +411,7 @@ namespace ProjectsTM.UI.MainForm
             if (m == null || d == null) return null;
             return _viewData.PickFilterdWorkItem(m, d);
         }
+
+        public bool IsDragActive() { return _workItemDragService.IsActive(); }
     }
 }

--- a/ProjectsTM.UI.TaskList/TaskListForm.cs
+++ b/ProjectsTM.UI.TaskList/TaskListForm.cs
@@ -1,5 +1,6 @@
 ﻿using ProjectsTM.Model;
 using ProjectsTM.ViewModel;
+using System;
 using System.Linq;
 using System.Windows.Forms;
 
@@ -10,16 +11,18 @@ namespace ProjectsTM.UI.TaskList
         private readonly ViewData _viewData;
         private PatternHistory _history;
         private FormSize _formSize;
+        private readonly Func<bool> _IsUpdateLock;
 
-        public TaskListForm(ViewData viewData, PatternHistory patternHistory, FormSize formSize)
+        public TaskListForm(ViewData viewData, PatternHistory patternHistory, FormSize formSize, Func<bool> IsUpdateLock)
         {
             InitializeComponent();
 
             this._viewData = viewData;
             this._history = patternHistory;
             this._formSize = formSize;
+            this._IsUpdateLock = IsUpdateLock;
             gridControl1.ListUpdated += GridControl1_ListUpdated;
-            gridControl1.Initialize(viewData, comboBoxPattern.Text, _formSize.TaskListColWidths);
+            gridControl1.Initialize(viewData, comboBoxPattern.Text, _formSize.TaskListColWidths, _IsUpdateLock);
             var offset = gridControl1.GridWidth - gridControl1.Width;
             this.Width += offset + gridControl1.VScrollBarWidth;
             this.Height = formSize?.TaskListFormHeight > this.Height ? formSize.TaskListFormHeight : this.Height;
@@ -50,7 +53,7 @@ namespace ProjectsTM.UI.TaskList
 
         public void Clear()
         {
-            gridControl1.Initialize(_viewData, comboBoxPattern.Text, _formSize.TaskListColWidths);
+            gridControl1.Initialize(_viewData, comboBoxPattern.Text, _formSize.TaskListColWidths, _IsUpdateLock);
         }
 
         private void comboBoxPattern_DropDown(object sender, System.EventArgs e)
@@ -67,7 +70,12 @@ namespace ProjectsTM.UI.TaskList
         private void UpdateList()
         {
             _history.Append(comboBoxPattern.Text);
-            gridControl1.Initialize(_viewData, comboBoxPattern.Text, _formSize.TaskListColWidths);
+            gridControl1.Initialize(_viewData, comboBoxPattern.Text, _formSize.TaskListColWidths, _IsUpdateLock);
+        }
+
+        public void ApplyEdit(WorkItems before, WorkItems after)
+        {
+            gridControl1.ApplyEdit(before, after);
         }
     }
 }

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -260,7 +260,7 @@ namespace ProjectsTM.UI.TaskList
             UpdateLastSelect();
         }
 
-        private void AddToEditedWorkItems(WorkItems before, WorkItems after, WorkItem errWorkItem)
+        private void AddErrToEditedWorkItems(WorkItem errWorkItem, WorkItems before, WorkItems after)
         {
             if (!before.Any(b => b.Equals(errWorkItem)))
             {
@@ -269,7 +269,7 @@ namespace ProjectsTM.UI.TaskList
             }
         }
 
-        private void AddToErrorList(Dictionary<WorkItem, string> errList, WorkItem errWorkItem, Dictionary<WorkItem, string> auditResult)
+        private void AddErrToErrorList(WorkItem errWorkItem, Dictionary<WorkItem, string> errList, Dictionary<WorkItem, string> auditResult)
         {
             if (!errList.TryGetValue(errWorkItem, out string str))
             {
@@ -285,8 +285,8 @@ namespace ProjectsTM.UI.TaskList
                 var auditResult = GetAuditErrors(a);
                 foreach (var errWorkItem in auditResult.Keys)
                 {
-                    AddToEditedWorkItems(before, after, errWorkItem);
-                    AddToErrorList(errList, errWorkItem, auditResult);
+                    AddErrToEditedWorkItems(errWorkItem, before, after);
+                    AddErrToErrorList(errWorkItem, errList, auditResult);
                 }
             }
         }

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -299,7 +299,7 @@ namespace ProjectsTM.UI.TaskList
                 if (listIdx == -1) throw new Exception("タスクリストにReplace対象が見つかりませんでした。");
                 var item = _listItems[listIdx];
                 _listItems[listIdx] = new TaskListItem(after.ElementAt(i), item.Color, item.IsMilestone,
-                    errMessages.TryGetValue(after.ElementAt(i), out string errMsg) ? errMsg : item.ErrMsg);
+                    errMessages.TryGetValue(after.ElementAt(i), out string errMsg) ? errMsg : String.Empty);
             }
         }
 

--- a/ProjectsTM.ViewModel/DragDoneEventArgs.cs
+++ b/ProjectsTM.ViewModel/DragDoneEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using ProjectsTM.Model;
+
+namespace ProjectsTM.ViewModel
+{
+    public class DragDoneEventArgs
+    {
+        public DragDoneEventArgs(WorkItems before, WorkItems after)
+        {
+            this.Before = before;
+            this.After = after;
+        }
+
+        public WorkItems Before{ get; }
+        public WorkItems After { get; }
+    }
+}

--- a/ProjectsTM.ViewModel/ProjectsTM.ViewModel.csproj
+++ b/ProjectsTM.ViewModel/ProjectsTM.ViewModel.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Detail.cs" />
+    <Compile Include="DragDoneEventArgs.cs" />
     <Compile Include="Filter.cs" />
     <Compile Include="IEditedEventArgs.cs" />
     <Compile Include="ImageBuffer.cs" />


### PR DESCRIPTION
タスクリストのパフォーマンス改善。下記のPRのリベンジ。
タスクリスト表示しながらのWorkItemGridドラッグが遅い問題の対策 #151

上記のPRはバックグランド更新などを前提として対策していたが、それらが不要になったため、
現行masterブランチの動き前提で作り直した。上記PR内の指摘は対応済。

■遅い原因
WorkItemGridドラッグ時にドラッグ位置に合わせてViewData.Selectedが更新され続け、
ViewData.Selected更新イベントによってタスクリストの_viewData_SelectedWorkItemChanged（）が繰り返し走ることが遅い原因。
またドラッグ完了時に毎回InitializeGrid()で更新してしまうことも遅い原因。

■対策①
WorkItemGridドラッグ時のViewData.Selected更新イベント起因では、タスクリストの更新を行わない。
（WorkItemDragService.IsActive()がTRUEの場合は、更新しない。）
代わりに、WorkItemGridドラッグ完了時に発火するイベント（NotifyDragDone）を追加し、
ドラッグ完了時のみドラッグによる編集内容をタスクリストへ反映する。

■対策②
ドラッグによる編集内容をタスクリストへ反映する際は、InitializeGrid（）を走らせない。
代わりに、TaskListGrid._listItemsからドラッグ編集対象を検索し、対象のみ更新する。