### PR TITLE
改善を２つ。

### DIFF
--- a/ProjectsTM.Service/AppDataFileIOService.cs
+++ b/ProjectsTM.Service/AppDataFileIOService.cs
@@ -115,6 +115,7 @@ namespace ProjectsTM.Service
             if (IsFutureVersion(fileName))
             {
                 MessageBox.Show("ご使用のツールより新しいバージョンで保存されたファイルです。ツールを更新してから開いてください。");
+                Environment.Exit(0);
                 return null;
             }
             _previousFileName = fileName;

--- a/ProjectsTM.Service/GitRepositoryService.cs
+++ b/ProjectsTM.Service/GitRepositoryService.cs
@@ -10,7 +10,7 @@ namespace ProjectsTM.Service
         {
             Task<bool> task = Task.Run(() =>
             {
-                if (!IsAcrive()) return false;
+                if (!IsActive()) return false;
                 if (string.IsNullOrEmpty(filePath)) return false;
                 var gitRepoPath = SearchGitRepo(filePath);
                 if (string.IsNullOrEmpty(gitRepoPath)) return false;
@@ -20,7 +20,7 @@ namespace ProjectsTM.Service
             return task;
         }
 
-        private static bool IsAcrive()
+        public static bool IsActive()
         {
             return !string.IsNullOrEmpty(GitCmd.GetVersion());
         }

--- a/ProjectsTM.Service/VersionUpdateService.cs
+++ b/ProjectsTM.Service/VersionUpdateService.cs
@@ -16,6 +16,7 @@ namespace ProjectsTM.Service
             if (!IsOldCurrentVersion(latestVersion)) return false;
             if (MessageBox.Show("ツールの最新版がリリースされています。配布先を開きますか？", "日程表ツール", MessageBoxButtons.YesNo) != DialogResult.Yes) return false;
             Process.Start(GetFileServerPath(dir));
+            Environment.Exit(0);
             return true;
         }
 


### PR DESCRIPTION
ほんとは分けたほうが良いけど、混ざっちゃいました。
・ツールの更新を促した後、そのまま起動継続していたのを、終了するように変更。
・リモートブランチの更新をファイルオープンだけじゃなくて、定期的（１分おき）にチェックするように対応。