### PR TITLE
新規メンバーを追加した際に、全てのフィルターで表示されないようにする

### DIFF
--- a/ProjectsTM.Model/AppData.cs
+++ b/ProjectsTM.Model/AppData.cs
@@ -4,7 +4,7 @@ namespace ProjectsTM.Model
 {
     public class AppData
     {
-        static public int DataVersion = 2; // 互換性のなくなる変更をしたときにこの数字を増やす //TODO:matsukage showMembers
+        static public int DataVersion = 2; // 互換性のなくなる変更をしたときにこの数字を増やす
         public int Version
         {
             set {; }

--- a/ProjectsTM.Model/AppData.cs
+++ b/ProjectsTM.Model/AppData.cs
@@ -4,7 +4,7 @@ namespace ProjectsTM.Model
 {
     public class AppData
     {
-        static public int DataVersion = 2; // 互換性のなくなる変更をしたときにこの数字を増やす
+        static public int DataVersion = 2; // 互換性のなくなる変更をしたときにこの数字を増やす //TODO:matsukage showMembers
         public int Version
         {
             set {; }

--- a/ProjectsTM.Model/Members.cs
+++ b/ProjectsTM.Model/Members.cs
@@ -21,6 +21,12 @@ namespace ProjectsTM.Model
             _members.Add(member);
         }
 
+        public void Remove(Member member)
+        {
+            if (!_members.Contains(member)) return;
+            _members.Remove(member);
+        }
+
         IEnumerator IEnumerable.GetEnumerator()
         {
             return _members.GetEnumerator();

--- a/ProjectsTM.Model/Members.cs
+++ b/ProjectsTM.Model/Members.cs
@@ -10,6 +10,13 @@ namespace ProjectsTM.Model
 
         public int Count => _members.Count;
 
+        public Members() { }
+
+        public Members(List<Member> memberList)
+        {
+            this._members = memberList;
+        }
+
         public IEnumerator<Member> GetEnumerator()
         {
             return _members.GetEnumerator();

--- a/ProjectsTM.Service/FilterComboBoxService.cs
+++ b/ProjectsTM.Service/FilterComboBoxService.cs
@@ -125,7 +125,7 @@ namespace ProjectsTM.Service
             var idx = toolStripComboBoxFilter.SelectedIndex;
             if (idx == 0)
             {
-                _viewData.SetFilter(Filter.All);
+                _viewData.SetFilter(Filter.All(_viewData));
                 return;
             }
             idx = idx - 1;

--- a/ProjectsTM.Service/FilterComboBoxService.cs
+++ b/ProjectsTM.Service/FilterComboBoxService.cs
@@ -153,7 +153,7 @@ namespace ProjectsTM.Service
             var members = new Members();
             foreach (var m in _viewData.Original.Members)
             {
-                if (!IsMemberMatchText(m, @"^\[.*?]\[.*?]\[.*?\(" + com + @"\)]\[.*?]\[.*?]")) members.Add(m);
+                if (IsMemberMatchText(m, @"^\[.*?]\[.*?]\[.*?\(" + com + @"\)]\[.*?]\[.*?]")) members.Add(m);
             }
             return new Filter(null, null, members, false, com);
         }
@@ -170,7 +170,7 @@ namespace ProjectsTM.Service
             var members = new Members();
             foreach (var m in _viewData.Original.Members)
             {
-                if (!IsMemberMatchText(m, @"^\[.*?\]\[" + pro.ToString() + @"\]")) members.Add(m);
+                if (IsMemberMatchText(m, @"^\[.*?\]\[" + pro.ToString() + @"\]")) members.Add(m);
             }
             return new Filter(null, null, members, false, pro.ToString());
         }
@@ -190,7 +190,9 @@ namespace ProjectsTM.Service
             using (var rs = StreamFactory.CreateReader(path))
             {
                 var x = new XmlSerializer(typeof(Filter));
-                return (Filter)x.Deserialize(rs);
+                Filter filter = (Filter)x.Deserialize(rs);
+                filter.SetShowMemersFromHideMembers(_viewData.CreateAllMembersList());
+                return filter;
             }
         }
     }

--- a/ProjectsTM.UI.MainForm/FilterForm.cs
+++ b/ProjectsTM.UI.MainForm/FilterForm.cs
@@ -57,7 +57,7 @@ namespace ProjectsTM.UI.MainForm
             checkedListBox1.DisplayMember = "NaturalString";
             foreach (var m in _members)
             {
-                var check = !_filter.HideMembers.Contains(m); //TODO:matsukage ShowMembers
+                var check = _filter.ShowMembers.Contains(m);
                 checkedListBox1.Items.Add(m, check);
             }
 

--- a/ProjectsTM.UI.MainForm/FilterForm.cs
+++ b/ProjectsTM.UI.MainForm/FilterForm.cs
@@ -57,7 +57,7 @@ namespace ProjectsTM.UI.MainForm
             checkedListBox1.DisplayMember = "NaturalString";
             foreach (var m in _members)
             {
-                var check = !_filter.HideMembers.Contains(m);
+                var check = !_filter.HideMembers.Contains(m); //TODO:matsukage ShowMembers
                 checkedListBox1.Items.Add(m, check);
             }
 

--- a/ProjectsTM.UI.MainForm/FilterForm.cs
+++ b/ProjectsTM.UI.MainForm/FilterForm.cs
@@ -124,7 +124,7 @@ namespace ProjectsTM.UI.MainForm
 
         public Filter GetFilter()
         {
-            return new Filter(GetWorkItemFilter(), GetPeriodFilter(), GetHiddenMembers(), checkBox_IsFreeTimeMemberShow.Checked, comboBox_MSFiltersSearchPattern.Text);
+            return new Filter(GetWorkItemFilter(), GetPeriodFilter(), GetCheckedMembers(), checkBox_IsFreeTimeMemberShow.Checked, comboBox_MSFiltersSearchPattern.Text);
         }
 
         private string GetWorkItemFilter()
@@ -139,17 +139,6 @@ namespace ProjectsTM.UI.MainForm
             var to = CallenderDay.Parse(textBoxTo.Text);
             if (from == null || to == null) return null;
             return new Period(from, to);
-        }
-
-        private Members GetHiddenMembers()
-        {
-            var result = new Members();
-            foreach (var c in checkedListBox1.Items)
-            {
-                var m = (Member)c;
-                if (!GetCheckedMembers().Contains(m)) result.Add(m);
-            }
-            return result;
         }
 
         private Members GetCheckedMembers()
@@ -194,6 +183,7 @@ namespace ProjectsTM.UI.MainForm
                 {
                     var s = new XmlSerializer(typeof(Filter));
                     _filter = (Filter)s.Deserialize(reader);
+                    _filter.SetShowMemersFromHideMembers(_originalMembers.ToList());
                     UpdateAllField();
                 }
             }

--- a/ProjectsTM.ViewModel/Filter.cs
+++ b/ProjectsTM.ViewModel/Filter.cs
@@ -7,16 +7,17 @@ namespace ProjectsTM.ViewModel
     public class Filter : IEquatable<Filter>
     {
         public Filter() { }
-        public Filter(string v, Period period, Members hideMembers, bool isFreeTimeMemberShow, string msFilterSearchPattern)
+        public Filter(string v, Period period, Members hideMembers, bool isFreeTimeMemberShow, string msFilterSearchPattern)　//TODO:matsukage showMembersを渡すようにする
         {
             if (v != null) WorkItem = v;
             if (period != null) Period = period;
-            if (hideMembers != null) HideMembers = hideMembers;
+            if (hideMembers != null) HideMembers = hideMembers;　//TODO:matsukage showMembers
             IsFreeTimeMemberShow = isFreeTimeMemberShow;
             if (MSFilterSearchPattern != null) MSFilterSearchPattern = msFilterSearchPattern;
         }
 
-        public Members HideMembers { get; private set; } = new Members();
+        public Members HideMembers { get; private set; } = new Members(); //TODO:matsukage 過去バージョンを考慮してgetできるようにするが、ShowMembersへ変換する
+        //TODO:matsukage ShowMembers追加
         public Period Period { get; set; } = new Period();
         public string WorkItem { get; set; } = string.Empty;
         public bool IsFreeTimeMemberShow { get; set; } = true;
@@ -26,7 +27,7 @@ namespace ProjectsTM.ViewModel
         public bool Equals(Filter other)
         {
             return other != null &&
-                   EqualityComparer<Members>.Default.Equals(HideMembers, other.HideMembers) &&
+                   EqualityComparer<Members>.Default.Equals(HideMembers, other.HideMembers) &&　//TODO:matsukage showMembers
                    EqualityComparer<Period>.Default.Equals(Period, other.Period) &&
                    WorkItem == other.WorkItem &&
                    IsFreeTimeMemberShow == other.IsFreeTimeMemberShow &&
@@ -36,7 +37,7 @@ namespace ProjectsTM.ViewModel
         public override int GetHashCode()
         {
             int hashCode = 69401243;
-            hashCode = hashCode * -1521134295 + EqualityComparer<Members>.Default.GetHashCode(HideMembers);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Members>.Default.GetHashCode(HideMembers); //TODO:matsukage ShowMembers
             hashCode = hashCode * -1521134295 + EqualityComparer<Period>.Default.GetHashCode(Period);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(WorkItem);
             hashCode = hashCode * -1521134295 + EqualityComparer<bool>.Default.GetHashCode(IsFreeTimeMemberShow);
@@ -47,7 +48,7 @@ namespace ProjectsTM.ViewModel
         public Filter Clone()
         {
             var result = Filter.All;
-            result.HideMembers = this.HideMembers.Clone();
+            result.HideMembers = this.HideMembers.Clone(); //TODO:ShowMembers
             result.WorkItem = (string)this.WorkItem.Clone();
             result.Period = this.Period.Clone();
             result.IsFreeTimeMemberShow = this.IsFreeTimeMemberShow;

--- a/ProjectsTM.ViewModel/Filter.cs
+++ b/ProjectsTM.ViewModel/Filter.cs
@@ -24,7 +24,7 @@ namespace ProjectsTM.ViewModel
             this.HideMembers = new Members();
         }
 
-        public Members HideMembers { get; private set; } = new Members(); //TODO:matsukage 過去バージョンを考慮してgetできるようにするが、ShowMembersへ変換する
+        public Members HideMembers { get; private set; } = new Members(); //TODO:過去バージョン考慮して残す。HideMembersが撲滅されたら消す
         public Members ShowMembers { get; private set; } = new Members();
         public Period Period { get; set; } = new Period();
         public string WorkItem { get; set; } = string.Empty;

--- a/ProjectsTM.ViewModel/Filter.cs
+++ b/ProjectsTM.ViewModel/Filter.cs
@@ -20,7 +20,7 @@ namespace ProjectsTM.ViewModel
         public void SetShowMemersFromHideMembers(List<Member> allMembers) //TODO:HideMembersが撲滅されたら消す
         {
             if (this.HideMembers.Count == 0) return;
-            this.ShowMembers = (Members)allMembers.Where(m => !this.HideMembers.Contains(m));
+            this.ShowMembers = new Members(allMembers.Where(m => !this.HideMembers.Contains(m)).ToList());
             this.HideMembers = new Members();
         }
 
@@ -30,7 +30,7 @@ namespace ProjectsTM.ViewModel
         public string WorkItem { get; set; } = string.Empty;
         public bool IsFreeTimeMemberShow { get; set; } = true;
         public string MSFilterSearchPattern { get; set; } = "ALL";
-        public static Filter All => new Filter(null, null, new Members(), false, "ALL");
+        public static Filter All(ViewData viewData) => new Filter(null, null, viewData != null? viewData.Original.Members:new Members(), false, "ALL");
 
         public bool Equals(Filter other)
         {
@@ -55,8 +55,8 @@ namespace ProjectsTM.ViewModel
 
         public Filter Clone()
         {
-            var result = Filter.All;
-            result.HideMembers = this.HideMembers.Clone(); //TODO:ShowMembers
+            var result = Filter.All(null);
+            result.ShowMembers = this.ShowMembers.Clone();
             result.WorkItem = (string)this.WorkItem.Clone();
             result.Period = this.Period.Clone();
             result.IsFreeTimeMemberShow = this.IsFreeTimeMemberShow;

--- a/ProjectsTM.ViewModel/Filter.cs
+++ b/ProjectsTM.ViewModel/Filter.cs
@@ -17,7 +17,7 @@ namespace ProjectsTM.ViewModel
         }
 
         public Members HideMembers { get; private set; } = new Members(); //TODO:matsukage 過去バージョンを考慮してgetできるようにするが、ShowMembersへ変換する
-        //TODO:matsukage ShowMembers追加
+        public Members ShowMembers { get; private set; } = new Members();
         public Period Period { get; set; } = new Period();
         public string WorkItem { get; set; } = string.Empty;
         public bool IsFreeTimeMemberShow { get; set; } = true;

--- a/ProjectsTM.ViewModel/Filter.cs
+++ b/ProjectsTM.ViewModel/Filter.cs
@@ -35,7 +35,7 @@ namespace ProjectsTM.ViewModel
         public bool Equals(Filter other)
         {
             return other != null &&
-                   EqualityComparer<Members>.Default.Equals(HideMembers, other.HideMembers) &&　//TODO:matsukage showMembers
+                   EqualityComparer<Members>.Default.Equals(ShowMembers, other.ShowMembers) &&
                    EqualityComparer<Period>.Default.Equals(Period, other.Period) &&
                    WorkItem == other.WorkItem &&
                    IsFreeTimeMemberShow == other.IsFreeTimeMemberShow &&
@@ -45,7 +45,7 @@ namespace ProjectsTM.ViewModel
         public override int GetHashCode()
         {
             int hashCode = 69401243;
-            hashCode = hashCode * -1521134295 + EqualityComparer<Members>.Default.GetHashCode(HideMembers); //TODO:matsukage ShowMembers
+            hashCode = hashCode * -1521134295 + EqualityComparer<Members>.Default.GetHashCode(ShowMembers);
             hashCode = hashCode * -1521134295 + EqualityComparer<Period>.Default.GetHashCode(Period);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(WorkItem);
             hashCode = hashCode * -1521134295 + EqualityComparer<bool>.Default.GetHashCode(IsFreeTimeMemberShow);

--- a/ProjectsTM.ViewModel/Filter.cs
+++ b/ProjectsTM.ViewModel/Filter.cs
@@ -1,19 +1,27 @@
 ﻿using ProjectsTM.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ProjectsTM.ViewModel
 {
     public class Filter : IEquatable<Filter>
     {
         public Filter() { }
-        public Filter(string v, Period period, Members hideMembers, bool isFreeTimeMemberShow, string msFilterSearchPattern)　//TODO:matsukage showMembersを渡すようにする
+        public Filter(string v, Period period, Members showMembers, bool isFreeTimeMemberShow, string msFilterSearchPattern)
         {
             if (v != null) WorkItem = v;
             if (period != null) Period = period;
-            if (hideMembers != null) HideMembers = hideMembers;　//TODO:matsukage showMembers
+            if (showMembers != null) ShowMembers = showMembers;
             IsFreeTimeMemberShow = isFreeTimeMemberShow;
             if (MSFilterSearchPattern != null) MSFilterSearchPattern = msFilterSearchPattern;
+        }
+
+        public void SetShowMemersFromHideMembers(List<Member> allMembers) //TODO:HideMembersが撲滅されたら消す
+        {
+            if (this.HideMembers.Count == 0) return;
+            this.ShowMembers = (Members)allMembers.Where(m => !this.HideMembers.Contains(m));
+            this.HideMembers = new Members();
         }
 
         public Members HideMembers { get; private set; } = new Members(); //TODO:matsukage 過去バージョンを考慮してgetできるようにするが、ShowMembersへ変換する

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -82,8 +82,8 @@ namespace ProjectsTM.ViewModel
         {
             if (Filter.IsFreeTimeMemberShow) return;
             var members = GetFilteredMembers();
-            if (members == null || members.Count() > 0) return;
-            var freeTimeMember = members.Where(m => !GetFilteredWorkItemsOfMember(m).HasWorkItem(Filter.Period));
+            if (members == null || members.Count() == 0) return;
+            var freeTimeMember = members.Where(m => !GetFilteredWorkItemsOfMember(m).HasWorkItem(Filter.Period.IsValid ? Filter.Period : null));
             foreach (var m in freeTimeMember)
             {
                 if (Filter.ShowMembers.Contains(m)) Filter.ShowMembers.Remove(m);

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -17,7 +17,7 @@ namespace ProjectsTM.ViewModel
         {
             _appData = appData;
             UndoService = undoService;
-            AddFreeTimeMembersToHideMembers(GetFilteredMembers());
+            AddFreeTimeMembersToHideMembers(GetFilteredMembers()); //TODO:matsukage RemoveFreeTimeMembersFromShowMembers
             AppDataChanged?.Invoke(this, null);
         }
 
@@ -62,7 +62,7 @@ namespace ProjectsTM.ViewModel
         {
             if (!Changed(filter)) return;
             Filter = filter;
-            AddFreeTimeMembersToHideMembers(GetFilteredMembers());
+            AddFreeTimeMembersToHideMembers(GetFilteredMembers()); //TODO:matsukage RemoveFreeTimeMemberersFromShowMembers
             FilterChanged(this, null);
         }
 
@@ -74,23 +74,23 @@ namespace ProjectsTM.ViewModel
         public IEnumerable<Member> GetFilteredMembers()
         {
             var result = CreateAllMembersList();
-            return RemoveFilterSettingMembers(result);
+            return RemoveFilterSettingMembers(result); //TODO:matsukage GetFilterShowMembers
         }
 
-        private void AddFreeTimeMembersToHideMembers(IEnumerable<Member> members)
+        private void AddFreeTimeMembersToHideMembers(IEnumerable<Member> members) //TODO:matsukage RemoveFreeTimeMemberersFromShowMembers
         {
             if (Filter.IsFreeTimeMemberShow) return;
             if (members == null || members.Count() > 0) return;
             var freeTimeMember = members.Where(m => !GetFilteredWorkItemsOfMember(m).HasWorkItem(Filter.Period));
             foreach (var m in freeTimeMember)
             {
-                if (!Filter.HideMembers.Contains(m)) Filter.HideMembers.Add(m);
+                if (!Filter.HideMembers.Contains(m)) Filter.HideMembers.Add(m); //TODO:matsukage ShowMembers
             }
         }
 
-        private List<Member> RemoveFilterSettingMembers(List<Member> members)
+        private List<Member> RemoveFilterSettingMembers(List<Member> members) //GetFilterShowMemberes
         {
-            return members.Where(m => !Filter.HideMembers.Contains(m)).ToList();
+            return members.Where(m => !Filter.HideMembers.Contains(m)).ToList();//TODO:matsukageShowMembers
         }
 
         private List<Member> CreateAllMembersList()

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -93,7 +93,7 @@ namespace ProjectsTM.ViewModel
             return members.Where(m => !Filter.HideMembers.Contains(m)).ToList();//TODO:matsukageShowMembers
         }
 
-        private List<Member> CreateAllMembersList()
+        public List<Member> CreateAllMembersList()
         {
             return this.Original.Members.ToList();
         }

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -17,7 +17,7 @@ namespace ProjectsTM.ViewModel
         {
             _appData = appData;
             UndoService = undoService;
-            AddFreeTimeMembersToHideMembers(GetFilteredMembers()); //TODO:matsukage RemoveFreeTimeMembersFromShowMembers
+            RemoveFreeTimeMembersFromFilter();
             AppDataChanged?.Invoke(this, null);
         }
 
@@ -62,7 +62,7 @@ namespace ProjectsTM.ViewModel
         {
             if (!Changed(filter)) return;
             Filter = filter;
-            AddFreeTimeMembersToHideMembers(GetFilteredMembers()); //TODO:matsukage RemoveFreeTimeMemberersFromShowMembers
+            RemoveFreeTimeMembersFromFilter();
             FilterChanged(this, null);
         }
 
@@ -74,23 +74,24 @@ namespace ProjectsTM.ViewModel
         public IEnumerable<Member> GetFilteredMembers()
         {
             var result = CreateAllMembersList();
-            return RemoveFilterSettingMembers(result); //TODO:matsukage GetFilterShowMembers
+            return GetFilterShowMembers(result);
         }
 
-        private void AddFreeTimeMembersToHideMembers(IEnumerable<Member> members) //TODO:matsukage RemoveFreeTimeMemberersFromShowMembers
+        private void RemoveFreeTimeMembersFromFilter()
         {
             if (Filter.IsFreeTimeMemberShow) return;
+            var members = GetFilteredMembers();
             if (members == null || members.Count() > 0) return;
             var freeTimeMember = members.Where(m => !GetFilteredWorkItemsOfMember(m).HasWorkItem(Filter.Period));
             foreach (var m in freeTimeMember)
             {
-                if (!Filter.HideMembers.Contains(m)) Filter.HideMembers.Add(m); //TODO:matsukage ShowMembers
+                if (Filter.ShowMembers.Contains(m)) Filter.ShowMembers.Remove(m);
             }
         }
 
-        private List<Member> RemoveFilterSettingMembers(List<Member> members) //GetFilterShowMemberes
+        private List<Member> GetFilterShowMembers(List<Member> members)
         {
-            return members.Where(m => !Filter.HideMembers.Contains(m)).ToList();//TODO:matsukageShowMembers
+            return members.Where(m => Filter.ShowMembers.Contains(m)).ToList();
         }
 
         public List<Member> CreateAllMembersList()

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -8,7 +8,7 @@ namespace ProjectsTM.ViewModel
 {
     public class ViewData
     {
-        public Filter Filter { get; private set; } = Filter.All;
+        public Filter Filter { get; private set; } = Filter.All(null);
         public Detail Detail { get; set; } = new Detail();
 
         public AppData Original => _appData;
@@ -17,6 +17,7 @@ namespace ProjectsTM.ViewModel
         {
             _appData = appData;
             UndoService = undoService;
+            if (this.Filter.Equals(Filter.All(null))) this.Filter = Filter.All(this);
             RemoveFreeTimeMembersFromFilter();
             AppDataChanged?.Invoke(this, null);
         }


### PR DESCRIPTION
・今のフィルター定義は「何を隠すか」という意味でHideMemberesとしていたが、
「何を見せるか」という意味のShowMembersへ変更

・過去バージョンフィルタを読んだ際は、HideMembersがShowMembersへ変換されるよう追加。過去バージョンで作られたフィルターは、全てインポート•エクスポートすれば、変換可能