### PR TITLE
二回目のAppDataセット時にALLフィルタが更新されない問題を修正

### DIFF
--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -17,7 +17,7 @@ namespace ProjectsTM.ViewModel
         {
             _appData = appData;
             UndoService = undoService;
-            if (this.Filter.Equals(Filter.All(null))) this.Filter = Filter.All(this);
+            this.Filter = Filter.All(this);
             RemoveFreeTimeMembersFromFilter();
             AppDataChanged?.Invoke(this, null);
         }


### PR DESCRIPTION
元の実装だと、ALLフィルタが初期値（Filter.All(null)）であった場合にしか、
ALLフィルタを更新（ShowMembersを更新）できない。

そのため、
二回目のAppDataセット時（別の日程表ファイルを開いた時など）のALLフィルタは
ひとつ前のAppDataによって作成されたALLフィルタとなってしまう。

AppDataをセットする際は常に
新しいALLフィルタへ更新するよう修正する。