### PR TITLE
コンストラクタMembers(List<Member> memberList)内部の要素コピーが浅い問題を修正。

### DIFF
--- a/ProjectsTM.Model/Members.cs
+++ b/ProjectsTM.Model/Members.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ProjectsTM.Model
 {
@@ -14,7 +15,7 @@ namespace ProjectsTM.Model
 
         public Members(List<Member> memberList)
         {
-            this._members = memberList;
+            this._members = memberList.Select(item => item.Clone()).ToList();
         }
 
         public IEnumerator<Member> GetEnumerator()


### PR DESCRIPTION
コンストラクタMembers(List<Member> memberList)　の内部の要素コピーが浅い問題を修正。

現段階で問題があるわけではないが、直感と異なるため、
member要素の実体が、引数で渡されたものとは別となるようにする。