### PR TITLE
メンバー管理に退社済み属性を追加

### DIFF
--- a/ProjectsTM.Model/AppData.cs
+++ b/ProjectsTM.Model/AppData.cs
@@ -4,7 +4,7 @@ namespace ProjectsTM.Model
 {
     public class AppData
     {
-        static public int DataVersion = 3; // 互換性のなくなる変更をしたときにこの数字を増やす
+        static public int DataVersion = 4; // 互換性のなくなる変更をしたときにこの数字を増やす
         public int Version
         {
             set {; }

--- a/ProjectsTM.Model/Member.cs
+++ b/ProjectsTM.Model/Member.cs
@@ -26,6 +26,14 @@ namespace ProjectsTM.Model
             }
         }
 
+        public MemberState State { get; set; } = MemberState.Woking;
+
+        public enum MemberState
+        {
+            Woking,
+            Retirement,
+        }
+
         internal Member Clone()
         {
             return Member.Parse(ToSerializeString());

--- a/ProjectsTM.Model/Member.cs
+++ b/ProjectsTM.Model/Member.cs
@@ -31,7 +31,7 @@ namespace ProjectsTM.Model
         public enum MemberState
         {
             Woking,
-            Retirement,
+            Retired,
         }
 
         internal Member Clone()

--- a/ProjectsTM.Model/Member.cs
+++ b/ProjectsTM.Model/Member.cs
@@ -34,7 +34,7 @@ namespace ProjectsTM.Model
             Retired,
         }
 
-        internal Member Clone()
+        public Member Clone()
         {
             return Member.Parse(this.ToSerializeString(), this.State);
         }

--- a/ProjectsTM.Model/Member.cs
+++ b/ProjectsTM.Model/Member.cs
@@ -28,12 +28,6 @@ namespace ProjectsTM.Model
 
         public MemberState State { get; set; } = MemberState.Woking;
 
-        public enum MemberState
-        {
-            Woking,
-            Retired,
-        }
-
         public Member Clone()
         {
             return Member.Parse(this.ToSerializeString(), this.State);

--- a/ProjectsTM.Model/Member.cs
+++ b/ProjectsTM.Model/Member.cs
@@ -36,7 +36,7 @@ namespace ProjectsTM.Model
 
         internal Member Clone()
         {
-            return Member.Parse(ToSerializeString());
+            return Member.Parse(this.ToSerializeString(), this.State);
         }
 
         /// <summary>
@@ -44,11 +44,12 @@ namespace ProjectsTM.Model
         /// </summary>
         public Member() { }
 
-        public Member(string lastName, string firstName, string company)
+        public Member(string lastName, string firstName, string company, MemberState state)
         {
             FirstName = firstName;
             LastName = lastName;
             Company = company;
+            State = state;
         }
 
         public string DisplayName
@@ -65,13 +66,14 @@ namespace ProjectsTM.Model
             }
         }
 
-        public void EditApply(string text)
+        public void EditApply(string text, MemberState state)
         {
-            var m = Member.Parse(text);
+            var m = Member.Parse(text, state);
             if (m == null) return;
             LastName = m.LastName;
             FirstName = m.FirstName;
             Company = m.Company;
+            State = m.State;
         }
 
         public string ToSerializeString()
@@ -81,11 +83,11 @@ namespace ProjectsTM.Model
 
         public string NaturalString => LastName + " " + FirstName + "(" + Company + ")";
 
-        public static Member Parse(string text)
+        public static Member Parse(string text, MemberState state)
         {
             var words = text.Split('/');
             if (words.Length < 3) return null;
-            return new Member(words[0], words[1], words[2]);
+            return new Member(words[0], words[1], words[2], state);
         }
 
         public override string ToString()

--- a/ProjectsTM.Model/MemberState.cs
+++ b/ProjectsTM.Model/MemberState.cs
@@ -1,0 +1,8 @@
+﻿namespace ProjectsTM.Model
+{
+    public enum MemberState
+    {
+        Woking,
+        Retired,
+    }
+}

--- a/ProjectsTM.Model/ProjectsTM.Model.csproj
+++ b/ProjectsTM.Model/ProjectsTM.Model.csproj
@@ -52,6 +52,7 @@
     <Compile Include="FormSize.cs" />
     <Compile Include="Member.cs" />
     <Compile Include="Members.cs" />
+    <Compile Include="MemberState.cs" />
     <Compile Include="MembersWorkItems.cs" />
     <Compile Include="MileStone.cs" />
     <Compile Include="MileStoneFilter.cs" />

--- a/ProjectsTM.Service/CsvReadService.cs
+++ b/ProjectsTM.Service/CsvReadService.cs
@@ -42,13 +42,13 @@ namespace ProjectsTM.Service
             switch (groups.Count)
             {
                 case 2:
-                    return new Member(groups[1].Value, "", "", Member.MemberState.Woking);
+                    return new Member(groups[1].Value, "", "", MemberState.Woking);
                 case 3:
-                    return new Member(groups[2].Value, "", groups[1].Value, Member.MemberState.Woking);
+                    return new Member(groups[2].Value, "", groups[1].Value, MemberState.Woking);
                 default:
                     break;
             }
-            return new Member("", "", "", Member.MemberState.Woking);
+            return new Member("", "", "", MemberState.Woking);
         }
 
         private static Period ParsePeriod(string from, string to)

--- a/ProjectsTM.Service/CsvReadService.cs
+++ b/ProjectsTM.Service/CsvReadService.cs
@@ -42,13 +42,13 @@ namespace ProjectsTM.Service
             switch (groups.Count)
             {
                 case 2:
-                    return new Member(groups[1].Value, "", "");
+                    return new Member(groups[1].Value, "", "", Member.MemberState.Woking); //TODO:matsukage mada
                 case 3:
-                    return new Member(groups[2].Value, "", groups[1].Value);
+                    return new Member(groups[2].Value, "", groups[1].Value, Member.MemberState.Woking); //TODO:matsukage mada
                 default:
                     break;
             }
-            return new Member("", "", "");
+            return new Member("", "", "", Member.MemberState.Woking);
         }
 
         private static Period ParsePeriod(string from, string to)

--- a/ProjectsTM.Service/CsvReadService.cs
+++ b/ProjectsTM.Service/CsvReadService.cs
@@ -42,9 +42,9 @@ namespace ProjectsTM.Service
             switch (groups.Count)
             {
                 case 2:
-                    return new Member(groups[1].Value, "", "", Member.MemberState.Woking); //TODO:matsukage mada
+                    return new Member(groups[1].Value, "", "", Member.MemberState.Woking);
                 case 3:
-                    return new Member(groups[2].Value, "", groups[1].Value, Member.MemberState.Woking); //TODO:matsukage mada
+                    return new Member(groups[2].Value, "", groups[1].Value, Member.MemberState.Woking);
                 default:
                     break;
             }

--- a/ProjectsTM.Service/DummyDataService.cs
+++ b/ProjectsTM.Service/DummyDataService.cs
@@ -40,7 +40,7 @@ namespace ProjectsTM.Service
             appData.Members = new Members();
             for (var member = 00; member < 100; member++)
             {
-                appData.Members.Add(new Member(member.ToString(), (100 - member).ToString(), "A", Member.MemberState.Woking));
+                appData.Members.Add(new Member(member.ToString(), (100 - member).ToString(), "A", MemberState.Woking));
             }
             appData.WorkItems = new WorkItems();
             var p = new Project("PRJ");

--- a/ProjectsTM.Service/DummyDataService.cs
+++ b/ProjectsTM.Service/DummyDataService.cs
@@ -40,7 +40,7 @@ namespace ProjectsTM.Service
             appData.Members = new Members();
             for (var member = 00; member < 100; member++)
             {
-                appData.Members.Add(new Member(member.ToString(), (100 - member).ToString(), "A"));
+                appData.Members.Add(new Member(member.ToString(), (100 - member).ToString(), "A", Member.MemberState.Woking));
             }
             appData.WorkItems = new WorkItems();
             var p = new Project("PRJ");

--- a/ProjectsTM.UI.Common/EditMemberForm.Designer.cs
+++ b/ProjectsTM.UI.Common/EditMemberForm.Designer.cs
@@ -31,6 +31,7 @@
             this.textBox1 = new System.Windows.Forms.TextBox();
             this.buttonOK = new System.Windows.Forms.Button();
             this.buttonCancel = new System.Windows.Forms.Button();
+            this.comboBox1 = new System.Windows.Forms.ComboBox();
             this.SuspendLayout();
             // 
             // textBox1
@@ -41,7 +42,7 @@
             this.textBox1.Location = new System.Drawing.Point(6, 9);
             this.textBox1.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
             this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(371, 19);
+            this.textBox1.Size = new System.Drawing.Size(289, 19);
             this.textBox1.TabIndex = 0;
             // 
             // buttonOK
@@ -69,6 +70,14 @@
             this.buttonCancel.UseVisualStyleBackColor = true;
             this.buttonCancel.Click += new System.EventHandler(this.ButtonCancel_Click);
             // 
+            // comboBox1
+            // 
+            this.comboBox1.FormattingEnabled = true;
+            this.comboBox1.Location = new System.Drawing.Point(299, 8);
+            this.comboBox1.Name = "comboBox1";
+            this.comboBox1.Size = new System.Drawing.Size(76, 20);
+            this.comboBox1.TabIndex = 2;
+            // 
             // EditMemberForm
             // 
             this.AcceptButton = this.buttonOK;
@@ -76,6 +85,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.buttonCancel;
             this.ClientSize = new System.Drawing.Size(503, 38);
+            this.Controls.Add(this.comboBox1);
             this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.buttonOK);
             this.Controls.Add(this.textBox1);
@@ -96,5 +106,6 @@
         private System.Windows.Forms.TextBox textBox1;
         private System.Windows.Forms.Button buttonOK;
         private System.Windows.Forms.Button buttonCancel;
+        private System.Windows.Forms.ComboBox comboBox1;
     }
 }

--- a/ProjectsTM.UI.Common/EditMemberForm.Designer.cs
+++ b/ProjectsTM.UI.Common/EditMemberForm.Designer.cs
@@ -72,6 +72,7 @@
             // 
             // comboBox1
             // 
+            this.comboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.comboBox1.FormattingEnabled = true;
             this.comboBox1.Location = new System.Drawing.Point(299, 8);
             this.comboBox1.Name = "comboBox1";

--- a/ProjectsTM.UI.Common/EditMemberForm.cs
+++ b/ProjectsTM.UI.Common/EditMemberForm.cs
@@ -1,17 +1,24 @@
-﻿using System;
+﻿using ProjectsTM.Model;
+using System;
 using System.Windows.Forms;
 
 namespace ProjectsTM.UI.Common
 {
     public partial class EditMemberForm : Form
     {
-        public EditMemberForm(string value)
+        public EditMemberForm(string value, Member.MemberState state)
         {
             InitializeComponent();
             textBox1.Text = value;
+            foreach(var s in System.Enum.GetValues(typeof(Member.MemberState)))
+            {
+                comboBox1.Items.Add(s.ToString());
+            }
+            comboBox1.SelectedIndex = (int)state;
         }
 
         public string EditText => textBox1.Text;
+        public int Selected => comboBox1.SelectedIndex;
 
         public bool ReadOnly
         {

--- a/ProjectsTM.UI.Common/EditMemberForm.cs
+++ b/ProjectsTM.UI.Common/EditMemberForm.cs
@@ -10,7 +10,7 @@ namespace ProjectsTM.UI.Common
         {
             InitializeComponent();
             textBox1.Text = m.ToSerializeString();
-            foreach(var s in System.Enum.GetValues(typeof(Member.MemberState)))
+            foreach(var s in System.Enum.GetValues(typeof(MemberState)))
             {
                 comboBox1.Items.Add(s.ToString());
             }

--- a/ProjectsTM.UI.Common/EditMemberForm.cs
+++ b/ProjectsTM.UI.Common/EditMemberForm.cs
@@ -6,15 +6,15 @@ namespace ProjectsTM.UI.Common
 {
     public partial class EditMemberForm : Form
     {
-        public EditMemberForm(string value, Member.MemberState state)
+        public EditMemberForm(Member m)
         {
             InitializeComponent();
-            textBox1.Text = value;
+            textBox1.Text = m.ToSerializeString();
             foreach(var s in System.Enum.GetValues(typeof(Member.MemberState)))
             {
                 comboBox1.Items.Add(s.ToString());
             }
-            comboBox1.SelectedIndex = (int)state;
+            comboBox1.SelectedIndex = (int)m.State;
         }
 
         public string EditText => textBox1.Text;

--- a/ProjectsTM.UI.Common/EditStringForm.Designer.cs
+++ b/ProjectsTM.UI.Common/EditStringForm.Designer.cs
@@ -1,0 +1,100 @@
+﻿namespace ProjectsTM.UI.Common
+{
+    partial class EditStringForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.textBox1 = new System.Windows.Forms.TextBox();
+            this.buttonOK = new System.Windows.Forms.Button();
+            this.buttonCancel = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // textBox1
+            // 
+            this.textBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.textBox1.Location = new System.Drawing.Point(6, 9);
+            this.textBox1.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.Size = new System.Drawing.Size(371, 19);
+            this.textBox1.TabIndex = 0;
+            // 
+            // buttonOK
+            // 
+            this.buttonOK.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.buttonOK.Location = new System.Drawing.Point(379, 9);
+            this.buttonOK.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
+            this.buttonOK.Name = "buttonOK";
+            this.buttonOK.Size = new System.Drawing.Size(47, 19);
+            this.buttonOK.TabIndex = 1;
+            this.buttonOK.Text = "OK";
+            this.buttonOK.UseVisualStyleBackColor = true;
+            this.buttonOK.Click += new System.EventHandler(this.ButtonOK_Click);
+            // 
+            // buttonCancel
+            // 
+            this.buttonCancel.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonCancel.Location = new System.Drawing.Point(428, 8);
+            this.buttonCancel.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(65, 20);
+            this.buttonCancel.TabIndex = 1;
+            this.buttonCancel.Text = "キャンセル";
+            this.buttonCancel.UseVisualStyleBackColor = true;
+            this.buttonCancel.Click += new System.EventHandler(this.ButtonCancel_Click);
+            // 
+            // EditStringForm
+            // 
+            this.AcceptButton = this.buttonOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.buttonCancel;
+            this.ClientSize = new System.Drawing.Size(503, 38);
+            this.Controls.Add(this.buttonCancel);
+            this.Controls.Add(this.buttonOK);
+            this.Controls.Add(this.textBox1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
+            this.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
+            this.MaximumSize = new System.Drawing.Size(1500, 77);
+            this.MinimumSize = new System.Drawing.Size(400, 77);
+            this.Name = "EditStringForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox textBox1;
+        private System.Windows.Forms.Button buttonOK;
+        private System.Windows.Forms.Button buttonCancel;
+    }
+}

--- a/ProjectsTM.UI.Common/EditStringForm.cs
+++ b/ProjectsTM.UI.Common/EditStringForm.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Windows.Forms;
+
+namespace ProjectsTM.UI.Common
+{
+    public partial class EditStringForm : Form
+    {
+        public EditStringForm(string value)
+        {
+            InitializeComponent();
+            textBox1.Text = value;
+        }
+
+        public string EditText => textBox1.Text;
+
+        public bool ReadOnly
+        {
+            set
+            {
+                textBox1.ReadOnly = value;
+            }
+            get
+            {
+                return textBox1.ReadOnly;
+            }
+        }
+
+        private void ButtonOK_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        private void ButtonCancel_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+            Close();
+        }
+    }
+}

--- a/ProjectsTM.UI.Common/EditStringForm.resx
+++ b/ProjectsTM.UI.Common/EditStringForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/ProjectsTM.UI.Common/EditWorkItemForm.cs
+++ b/ProjectsTM.UI.Common/EditWorkItemForm.cs
@@ -64,7 +64,7 @@ namespace ProjectsTM.UI.Common
 
         private bool ValidateAssignedMember()
         {
-            return _members.Contains(Member.Parse(textBoxMember.Text));
+            return _members.Contains(Member.Parse(textBoxMember.Text, Member.MemberState.Woking));
         }
 
         bool CheckEdit()
@@ -92,7 +92,7 @@ namespace ProjectsTM.UI.Common
 
         private Member GetAssignedMember()
         {
-            return Member.Parse(textBoxMember.Text);
+            return Member.Parse(textBoxMember.Text, Member.MemberState.Woking);
         }
 
         private static Period GetPeriod(Callender callender, string fromText, string toText)

--- a/ProjectsTM.UI.Common/EditWorkItemForm.cs
+++ b/ProjectsTM.UI.Common/EditWorkItemForm.cs
@@ -150,7 +150,7 @@ namespace ProjectsTM.UI.Common
         {
             var wi = CreateWorkItem(_callender);
             if (wi == null) return;
-            using (var dlg = new EditMemberForm(Regex.Escape(wi.ToString())))
+            using (var dlg = new EditStringForm(Regex.Escape(wi.ToString())))
             {
                 dlg.Text = "正規表現エスケープ";
                 dlg.ReadOnly = true;

--- a/ProjectsTM.UI.Common/EditWorkItemForm.cs
+++ b/ProjectsTM.UI.Common/EditWorkItemForm.cs
@@ -64,7 +64,7 @@ namespace ProjectsTM.UI.Common
 
         private bool ValidateAssignedMember()
         {
-            return _members.Contains(Member.Parse(textBoxMember.Text, Member.MemberState.Woking));
+            return _members.Contains(Member.Parse(textBoxMember.Text, MemberState.Woking));
         }
 
         bool CheckEdit()
@@ -92,7 +92,7 @@ namespace ProjectsTM.UI.Common
 
         private Member GetAssignedMember()
         {
-            return Member.Parse(textBoxMember.Text, Member.MemberState.Woking);
+            return Member.Parse(textBoxMember.Text, MemberState.Woking);
         }
 
         private static Period GetPeriod(Callender callender, string fromText, string toText)

--- a/ProjectsTM.UI.Common/ProjectsTM.UI.Common.csproj
+++ b/ProjectsTM.UI.Common/ProjectsTM.UI.Common.csproj
@@ -45,6 +45,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EditStringForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="EditStringForm.Designer.cs">
+      <DependentUpon>EditStringForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="EditMemberForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -66,6 +72,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="EditStringForm.resx">
+      <DependentUpon>EditStringForm.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="EditMemberForm.resx">
       <DependentUpon>EditMemberForm.cs</DependentUpon>
     </EmbeddedResource>

--- a/ProjectsTM.UI.MainForm/FilterForm.cs
+++ b/ProjectsTM.UI.MainForm/FilterForm.cs
@@ -271,7 +271,7 @@ namespace ProjectsTM.UI.MainForm
 
         private void buttonGenerateFromWorkItems_Click(object sender, EventArgs e)
         {
-            using (var dlg = new EditMemberForm(""))
+            using (var dlg = new EditStringForm(""))
             {
                 dlg.Text = "作業項目の正規表現";
                 if (dlg.ShowDialog() != DialogResult.OK) return;

--- a/ProjectsTM.UI.MainForm/ManageMemberForm.cs
+++ b/ProjectsTM.UI.MainForm/ManageMemberForm.cs
@@ -58,7 +58,7 @@ namespace ProjectsTM.UI.MainForm
             using (var dlg = new EditMemberForm(m.Clone()))
             {
                 if (dlg.ShowDialog() != DialogResult.OK) return;
-                var state = (Member.MemberState)dlg.Selected;
+                var state = (MemberState)dlg.Selected;
                 var after = Member.Parse(dlg.EditText, state);
                 if (after == null) return;
                 foreach (var w in _appData.WorkItems)
@@ -80,7 +80,7 @@ namespace ProjectsTM.UI.MainForm
             using (var dlg = new EditMemberForm(new Member()))
             {
                 if (dlg.ShowDialog() != DialogResult.OK) return;
-                var after = Member.Parse(dlg.EditText, (Member.MemberState)dlg.Selected);
+                var after = Member.Parse(dlg.EditText, (MemberState)dlg.Selected);
                 if (after == null) return;
                 _appData.Members.Add(after);
             }

--- a/ProjectsTM.UI.MainForm/ManageMemberForm.cs
+++ b/ProjectsTM.UI.MainForm/ManageMemberForm.cs
@@ -55,7 +55,7 @@ namespace ProjectsTM.UI.MainForm
         {
             var m = listBox1.SelectedItem as Member;
             if (m == null) return;
-            using (var dlg = new EditMemberForm(m.ToSerializeString(), m.State))
+            using (var dlg = new EditMemberForm(m.Clone()))
             {
                 if (dlg.ShowDialog() != DialogResult.OK) return;
                 var state = (Member.MemberState)dlg.Selected;
@@ -77,7 +77,7 @@ namespace ProjectsTM.UI.MainForm
 
         private void ButtonAdd_Click(object sender, EventArgs e)
         {
-            using (var dlg = new EditMemberForm((new Member()).ToSerializeString(), Member.MemberState.Woking))
+            using (var dlg = new EditMemberForm(new Member()))
             {
                 if (dlg.ShowDialog() != DialogResult.OK) return;
                 var after = Member.Parse(dlg.EditText, (Member.MemberState)dlg.Selected);

--- a/ProjectsTM.UI.MainForm/ManageMemberForm.cs
+++ b/ProjectsTM.UI.MainForm/ManageMemberForm.cs
@@ -55,16 +55,17 @@ namespace ProjectsTM.UI.MainForm
         {
             var m = listBox1.SelectedItem as Member;
             if (m == null) return;
-            using (var dlg = new EditMemberForm(m.ToSerializeString()))
+            using (var dlg = new EditMemberForm(m.ToSerializeString(), m.State))
             {
                 if (dlg.ShowDialog() != DialogResult.OK) return;
-                var after = Member.Parse(dlg.EditText);
+                var state = (Member.MemberState)dlg.Selected;
+                var after = Member.Parse(dlg.EditText, state);
                 if (after == null) return;
                 foreach (var w in _appData.WorkItems)
                 {
                     if (m.Equals(w.AssignedMember)) w.AssignedMember = after;
                 }
-                m.EditApply(dlg.EditText);
+                m.EditApply(dlg.EditText, state);
             }
             UpdateList();
         }
@@ -76,10 +77,10 @@ namespace ProjectsTM.UI.MainForm
 
         private void ButtonAdd_Click(object sender, EventArgs e)
         {
-            using (var dlg = new EditMemberForm((new Member()).ToSerializeString()))
+            using (var dlg = new EditMemberForm((new Member()).ToSerializeString(), Member.MemberState.Woking))
             {
                 if (dlg.ShowDialog() != DialogResult.OK) return;
-                var after = Member.Parse(dlg.EditText);
+                var after = Member.Parse(dlg.EditText, (Member.MemberState)dlg.Selected);
                 if (after == null) return;
                 _appData.Members.Add(after);
             }

--- a/ProjectsTM.UI.MainForm/SearchWorkitemForm.cs
+++ b/ProjectsTM.UI.MainForm/SearchWorkitemForm.cs
@@ -131,7 +131,7 @@ namespace ProjectsTM.UI.MainForm
                     "↑" + ms.Name,
                     new Tags(new List<string>() { "" }),
                     new Period(ms.Day, ms.Day),
-                    new Member(string.Empty, string.Empty, string.Empty),
+                    new Member(string.Empty, string.Empty, string.Empty, Member.MemberState.Woking),
                     TaskState.Active,
                     string.Empty
                     );

--- a/ProjectsTM.UI.MainForm/SearchWorkitemForm.cs
+++ b/ProjectsTM.UI.MainForm/SearchWorkitemForm.cs
@@ -131,7 +131,7 @@ namespace ProjectsTM.UI.MainForm
                     "↑" + ms.Name,
                     new Tags(new List<string>() { "" }),
                     new Period(ms.Day, ms.Day),
-                    new Member(string.Empty, string.Empty, string.Empty, Member.MemberState.Woking),
+                    new Member(string.Empty, string.Empty, string.Empty, MemberState.Woking),
                     TaskState.Active,
                     string.Empty
                     );

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -97,7 +97,7 @@ namespace ProjectsTM.ViewModel
 
         public List<Member> CreateAllMembersList()
         {
-            return this.Original.Members.Where(item => item.State == Member.MemberState.Woking).ToList();
+            return this.Original.Members.Where(item => item.State == MemberState.Woking).ToList();
         }
 
         public WorkItem PickFilterdWorkItem(Member m, CallenderDay d)

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -97,7 +97,7 @@ namespace ProjectsTM.ViewModel
 
         public List<Member> CreateAllMembersList()
         {
-            return this.Original.Members.ToList();
+            return this.Original.Members.Where(item => item.State == Member.MemberState.Woking).ToList();
         }
 
         public WorkItem PickFilterdWorkItem(Member m, CallenderDay d)

--- a/UnitTest/UnitTestProject/UnitTest1.cs
+++ b/UnitTest/UnitTestProject/UnitTest1.cs
@@ -37,7 +37,7 @@ namespace UnitTestProject1
         [TestMethod]
         public void TestTeamMemberFormat()
         {
-            var member = new Member("下村", "圭矢", "AA", Member.MemberState.Woking);
+            var member = new Member("下村", "圭矢", "AA", MemberState.Woking);
             Assert.AreEqual<string>("下村 圭矢(AA)", member.ToString());
         }
 
@@ -55,7 +55,7 @@ namespace UnitTestProject1
         public void TestWorkItemFormat()
         {
             var callender = new Callender();
-            var wi = new WorkItem(new Project("Z123"), "仕様検討", new Tags(new List<string> { "a", "b" }), new Period(new CallenderDay(2019, 3, 20), new CallenderDay(2019, 3, 22)), new Member("A", "B", "C", Member.MemberState.Woking), TaskState.Active, "TestDescription");
+            var wi = new WorkItem(new Project("Z123"), "仕様検討", new Tags(new List<string> { "a", "b" }), new Period(new CallenderDay(2019, 3, 20), new CallenderDay(2019, 3, 22)), new Member("A", "B", "C", MemberState.Woking), TaskState.Active, "TestDescription");
             callender.Add(new CallenderDay(2019, 3, 20));
             callender.Add(new CallenderDay(2019, 3, 21));
             callender.Add(new CallenderDay(2019, 3, 22));
@@ -98,8 +98,8 @@ namespace UnitTestProject1
         private static AppData BuildDummyData()
         {
             var orgApp = new AppData();
-            var ichiro = new Member("鈴木", "イチロー", "マリナーズ", Member.MemberState.Woking);
-            var gozzila = new Member("松井", "秀喜", "ヤンキース", Member.MemberState.Woking);
+            var ichiro = new Member("鈴木", "イチロー", "マリナーズ", MemberState.Woking);
+            var gozzila = new Member("松井", "秀喜", "ヤンキース", MemberState.Woking);
             orgApp.Members.Add(ichiro);
             orgApp.Members.Add(gozzila);
             orgApp.Callender.Add(new CallenderDay(2018, 4, 1));
@@ -156,7 +156,7 @@ namespace UnitTestProject1
         [TestMethod]
         public void DesirializeReternCode()
         {
-            var w = new WorkItem(new Project("Z123"), "仕様検討", new Tags(new List<string> { "a", "b" }), new Period(new CallenderDay(2019, 3, 20), new CallenderDay(2019, 3, 22)), new Member("A", "B", "C", Member.MemberState.Woking), TaskState.Active, "TestDescription");
+            var w = new WorkItem(new Project("Z123"), "仕様検討", new Tags(new List<string> { "a", "b" }), new Period(new CallenderDay(2019, 3, 20), new CallenderDay(2019, 3, 22)), new Member("A", "B", "C", MemberState.Woking), TaskState.Active, "TestDescription");
             w.Description = "aaa" + Environment.NewLine + "bbb";
             var c = w.Clone();
             Assert.AreEqual(w.Description, c.Description);

--- a/UnitTest/UnitTestProject/UnitTest1.cs
+++ b/UnitTest/UnitTestProject/UnitTest1.cs
@@ -37,7 +37,7 @@ namespace UnitTestProject1
         [TestMethod]
         public void TestTeamMemberFormat()
         {
-            var member = new Member("下村", "圭矢", "AA");
+            var member = new Member("下村", "圭矢", "AA", Member.MemberState.Woking);
             Assert.AreEqual<string>("下村 圭矢(AA)", member.ToString());
         }
 
@@ -55,7 +55,7 @@ namespace UnitTestProject1
         public void TestWorkItemFormat()
         {
             var callender = new Callender();
-            var wi = new WorkItem(new Project("Z123"), "仕様検討", new Tags(new List<string> { "a", "b" }), new Period(new CallenderDay(2019, 3, 20), new CallenderDay(2019, 3, 22)), new Member("A", "B", "C"), TaskState.Active, "TestDescription");
+            var wi = new WorkItem(new Project("Z123"), "仕様検討", new Tags(new List<string> { "a", "b" }), new Period(new CallenderDay(2019, 3, 20), new CallenderDay(2019, 3, 22)), new Member("A", "B", "C", Member.MemberState.Woking), TaskState.Active, "TestDescription");
             callender.Add(new CallenderDay(2019, 3, 20));
             callender.Add(new CallenderDay(2019, 3, 21));
             callender.Add(new CallenderDay(2019, 3, 22));
@@ -98,8 +98,8 @@ namespace UnitTestProject1
         private static AppData BuildDummyData()
         {
             var orgApp = new AppData();
-            var ichiro = new Member("鈴木", "イチロー", "マリナーズ");
-            var gozzila = new Member("松井", "秀喜", "ヤンキース");
+            var ichiro = new Member("鈴木", "イチロー", "マリナーズ", Member.MemberState.Woking);
+            var gozzila = new Member("松井", "秀喜", "ヤンキース", Member.MemberState.Woking);
             orgApp.Members.Add(ichiro);
             orgApp.Members.Add(gozzila);
             orgApp.Callender.Add(new CallenderDay(2018, 4, 1));
@@ -156,7 +156,7 @@ namespace UnitTestProject1
         [TestMethod]
         public void DesirializeReternCode()
         {
-            var w = new WorkItem(new Project("Z123"), "仕様検討", new Tags(new List<string> { "a", "b" }), new Period(new CallenderDay(2019, 3, 20), new CallenderDay(2019, 3, 22)), new Member("A", "B", "C"), TaskState.Active, "TestDescription");
+            var w = new WorkItem(new Project("Z123"), "仕様検討", new Tags(new List<string> { "a", "b" }), new Period(new CallenderDay(2019, 3, 20), new CallenderDay(2019, 3, 22)), new Member("A", "B", "C", Member.MemberState.Woking), TaskState.Active, "TestDescription");
             w.Description = "aaa" + Environment.NewLine + "bbb";
             var c = w.Clone();
             Assert.AreEqual(w.Description, c.Description);


### PR DESCRIPTION
■MemberにMemberState (Working or Retirement)を追加

■EditMemberFormにMemberStateを設定するためのComboBoxを追加

■EditMeberFormはメンバ編集だけでなく、文字列編集ダイアログとして使いまわされていたので、
　文字列編集専用ダイアログとしてEditStringFormを追加。
　このEditStringFormは 本PR以前のEditMemberFormから変更ない（こちらにはMemberState設定ComboBoxはない）。

■MemberStateがWokingのメンバーしかグリッド上に表示されないよう変更
