### PR TITLE
new WorkItem( )した際にTaskStateがNew(仕様削除した状態)になってしまう問題を修正。

### DIFF
--- a/ProjectsTM.Model/WorkItem.cs
+++ b/ProjectsTM.Model/WorkItem.cs
@@ -33,7 +33,7 @@ namespace ProjectsTM.Model
             set { Tags = Tags.Parse(value); }
         }
 
-        private TaskState _state;
+        private TaskState _state = TaskState.Active;
         public TaskState State
         {
             get { return _state; }


### PR DESCRIPTION
new WorkItem( )された際にTaskStateがNew(仕様削除した状態)になってしまう問題を修正。
WorkItem._stateが初期化されていないので、enumの初期値であるNew(仕様削除した状態)になってしまっていた。
これにより、「作業項目の追加ダイアログ」でcomboBoxState.SelectedItemにNewがセットされてしまっていた。