### PR TITLE
TaskListFormの下部分に出る人月単位の工数を小数第一位まで表示

### DIFF
--- a/ProjectsTM.UI.TaskList/TaskListForm.cs
+++ b/ProjectsTM.UI.TaskList/TaskListForm.cs
@@ -46,8 +46,8 @@ namespace ProjectsTM.UI.TaskList
         private void UpdateLabelSum()
         {
             var dayCount = gridControl1.GetDayCount();
-            var monthCount = dayCount / 20;
-            labelSum.Text = dayCount.ToString() + "day (" + monthCount.ToString() + "人月)";
+            var monthCount = (dayCount / 20f);
+            labelSum.Text = string.Format("{0}day {1:0.0}人月 ", dayCount, monthCount);
         }
 
         private void TaskListForm_FormClosed(object sender, FormClosedEventArgs e)


### PR DESCRIPTION
TaskListFormの下部分に出る人月単位の工数を小数第一位まで表示するように変更しました。