### PR TITLE
メンバーの編集画面で、全メンバー数や各所属ごとの人数を表示するように対応しました。

### DIFF
--- a/ProjectsTM.Service/CountMemberNumService.cs
+++ b/ProjectsTM.Service/CountMemberNumService.cs
@@ -1,41 +1,23 @@
 ﻿using ProjectsTM.Model;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Runtime.CompilerServices;
 
 namespace ProjectsTM.Service
 {
     public static class CountMemberNumService
     {
-        public  static string GetCountStr(Members members )
+        public  static string GetCountStr(Members members)
         {
-            var temp = new HashSet<string>();
-            foreach (var m in members)
-            {
-                var belengTo = m.Company;
-                temp.Add(belengTo);
-            }
-            var companyList = temp.ToArray();
+            var companyList = GetCompanyList(members);
 
-            var countList = new List<int>();
-            int count;
-            foreach (var i in companyList)
-            {
-                count = 0;
-                foreach (var m in members)
-                {
-                    if (i.Equals(m.Company))
-                    {
-                        count++;
-                    }
-                }
-                countList.Add(count);
-            }
-            count = 0;
+            var countList = GetCountList(members, companyList).ToList();
+
+            var count = 0;
             string dispStr = string.Format("Total:{0} (", members.Count);
-            foreach (var i in companyList)
+            foreach (var company in companyList)
             {
-                dispStr += Concat(i, countList[count]);
+                dispStr += Concat(company, countList[count]);
                 count++;
             }
             return dispStr + ")";
@@ -45,5 +27,36 @@ namespace ProjectsTM.Service
         {
             return $"{belongTo}:{count} ";
         }
+
+        private static IEnumerable<string> GetCompanyList(Members members)
+        {
+            var companyList = new HashSet<string>();
+            foreach (var m in members)
+            {
+                var belengTo = m.Company;
+                companyList.Add(belengTo);
+            }
+            return companyList;
+        }
+
+        private static IEnumerable<int> GetCountList(Members members, IEnumerable<string> companyList)
+        {
+            var countList = new List<int>();
+            int count;
+            foreach (var company in companyList)
+            {
+                count = 0;
+                foreach (var member in members)
+                {
+                    if (company.Equals(member.Company))
+                    {
+                        count++;
+                    }
+                }
+                countList.Add(count);
+            }
+            return countList;
+        }
+
     }
 }

--- a/ProjectsTM.Service/CountMemberNumService.cs
+++ b/ProjectsTM.Service/CountMemberNumService.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ProjectsTM.Model;
+
+
+namespace ProjectsTM.Service
+{
+    public static class CountMemberNumService
+    {
+        public  static string GetCountStr(AppData appData )
+        {
+            var temp = new HashSet<string>();
+            foreach (var m in appData.Members)
+            {
+                var belengTo = m.Company;
+                temp.Add(belengTo);
+            }
+            var CompanyList = temp.ToArray();
+
+            var countList = new List<int>();
+            int count;
+            foreach (var i in CompanyList)
+            {
+                count = 0;
+                foreach (var m in appData.Members)
+                {
+                    if (i.Equals(m.Company))
+                    {
+                        count++;
+                    }
+                }
+                countList.Add(count);
+            }
+            count = 0;
+            string dispStr = string.Format("Total:{0} (", appData.Members.Count);
+            foreach (var i in CompanyList)
+            {
+                dispStr += Concat(i, countList[count]);
+                count++;
+            }
+            return dispStr + ")";
+        }
+
+        private static string Concat(string belongTo, int count)
+        {
+            return $"{belongTo}:{count} ";
+        }
+    }
+}

--- a/ProjectsTM.Service/CountMemberNumService.cs
+++ b/ProjectsTM.Service/CountMemberNumService.cs
@@ -1,31 +1,28 @@
-﻿using System;
+﻿using ProjectsTM.Model;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using ProjectsTM.Model;
 
 
 namespace ProjectsTM.Service
 {
     public static class CountMemberNumService
     {
-        public  static string GetCountStr(AppData appData )
+        public  static string GetCountStr(Members members )
         {
             var temp = new HashSet<string>();
-            foreach (var m in appData.Members)
+            foreach (var m in members)
             {
                 var belengTo = m.Company;
                 temp.Add(belengTo);
             }
-            var CompanyList = temp.ToArray();
+            var companyList = temp.ToArray();
 
             var countList = new List<int>();
             int count;
-            foreach (var i in CompanyList)
+            foreach (var i in companyList)
             {
                 count = 0;
-                foreach (var m in appData.Members)
+                foreach (var m in members)
                 {
                     if (i.Equals(m.Company))
                     {
@@ -35,8 +32,8 @@ namespace ProjectsTM.Service
                 countList.Add(count);
             }
             count = 0;
-            string dispStr = string.Format("Total:{0} (", appData.Members.Count);
-            foreach (var i in CompanyList)
+            string dispStr = string.Format("Total:{0} (", members.Count);
+            foreach (var i in companyList)
             {
                 dispStr += Concat(i, countList[count]);
                 count++;

--- a/ProjectsTM.Service/CountMemberNumService.cs
+++ b/ProjectsTM.Service/CountMemberNumService.cs
@@ -2,61 +2,21 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace ProjectsTM.Service
 {
     public static class CountMemberNumService
     {
-        public  static string GetCountStr(Members members)
+        public  static string GetCountStr(Members members, string selectedCompany)
         {
-            var companyList = GetCompanyList(members);
+            var count = members.Count(m => m.Company.Equals(selectedCompany));
 
-            var countList = GetCountList(members, companyList).ToList();
+            var result = new StringBuilder("Total:" + members.Count.ToString() + " (");
 
-            var count = 0;
-            string dispStr = string.Format("Total:{0} (", members.Count);
-            foreach (var company in companyList)
-            {
-                dispStr += Concat(company, countList[count]);
-                count++;
-            }
-            return dispStr + ")";
+            result.Append(selectedCompany + ":" + count.ToString());
+
+            return result.ToString() + ")"; 
         }
-
-        private static string Concat(string belongTo, int count)
-        {
-            return $"{belongTo}:{count} ";
-        }
-
-        private static IEnumerable<string> GetCompanyList(Members members)
-        {
-            var companyList = new HashSet<string>();
-            foreach (var m in members)
-            {
-                var belengTo = m.Company;
-                companyList.Add(belengTo);
-            }
-            return companyList;
-        }
-
-        private static IEnumerable<int> GetCountList(Members members, IEnumerable<string> companyList)
-        {
-            var countList = new List<int>();
-            int count;
-            foreach (var company in companyList)
-            {
-                count = 0;
-                foreach (var member in members)
-                {
-                    if (company.Equals(member.Company))
-                    {
-                        count++;
-                    }
-                }
-                countList.Add(count);
-            }
-            return countList;
-        }
-
     }
 }

--- a/ProjectsTM.Service/ProjectsTM.Service.csproj
+++ b/ProjectsTM.Service/ProjectsTM.Service.csproj
@@ -49,6 +49,7 @@
     <Compile Include="AppDataSerializeService.cs" />
     <Compile Include="AtomicAction.cs" />
     <Compile Include="CalculateSumService.cs" />
+    <Compile Include="CountMemberNumService.cs" />
     <Compile Include="CsvReadService.cs" />
     <Compile Include="DragState.cs" />
     <Compile Include="DrawService.cs" />

--- a/ProjectsTM.UI.MainForm/ManageMemberForm.Designer.cs
+++ b/ProjectsTM.UI.MainForm/ManageMemberForm.Designer.cs
@@ -33,6 +33,7 @@
             this.buttonDown = new System.Windows.Forms.Button();
             this.buttonEdit = new System.Windows.Forms.Button();
             this.buttonAdd = new System.Windows.Forms.Button();
+            this._labelMenmberNum = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // listBox1
@@ -41,21 +42,21 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.listBox1.FormattingEnabled = true;
-            this.listBox1.ItemHeight = 12;
-            this.listBox1.Location = new System.Drawing.Point(6, 6);
-            this.listBox1.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
+            this.listBox1.ItemHeight = 18;
+            this.listBox1.Location = new System.Drawing.Point(10, 9);
+            this.listBox1.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.listBox1.Name = "listBox1";
-            this.listBox1.Size = new System.Drawing.Size(286, 208);
+            this.listBox1.Size = new System.Drawing.Size(482, 346);
             this.listBox1.TabIndex = 0;
             this.listBox1.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.ListBox1_MouseDoubleClick);
             // 
             // buttonUp
             // 
             this.buttonUp.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonUp.Location = new System.Drawing.Point(306, 34);
-            this.buttonUp.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
+            this.buttonUp.Location = new System.Drawing.Point(518, 51);
+            this.buttonUp.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.buttonUp.Name = "buttonUp";
-            this.buttonUp.Size = new System.Drawing.Size(50, 26);
+            this.buttonUp.Size = new System.Drawing.Size(83, 39);
             this.buttonUp.TabIndex = 1;
             this.buttonUp.Text = "UP";
             this.buttonUp.UseVisualStyleBackColor = true;
@@ -64,10 +65,10 @@
             // buttonDown
             // 
             this.buttonDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonDown.Location = new System.Drawing.Point(306, 76);
-            this.buttonDown.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
+            this.buttonDown.Location = new System.Drawing.Point(518, 114);
+            this.buttonDown.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.buttonDown.Name = "buttonDown";
-            this.buttonDown.Size = new System.Drawing.Size(50, 26);
+            this.buttonDown.Size = new System.Drawing.Size(83, 39);
             this.buttonDown.TabIndex = 1;
             this.buttonDown.Text = "DOWN";
             this.buttonDown.UseVisualStyleBackColor = true;
@@ -76,10 +77,10 @@
             // buttonEdit
             // 
             this.buttonEdit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.buttonEdit.Location = new System.Drawing.Point(306, 116);
-            this.buttonEdit.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
+            this.buttonEdit.Location = new System.Drawing.Point(518, 174);
+            this.buttonEdit.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.buttonEdit.Name = "buttonEdit";
-            this.buttonEdit.Size = new System.Drawing.Size(50, 26);
+            this.buttonEdit.Size = new System.Drawing.Size(83, 39);
             this.buttonEdit.TabIndex = 1;
             this.buttonEdit.Text = "編集";
             this.buttonEdit.UseVisualStyleBackColor = true;
@@ -87,26 +88,38 @@
             // 
             // buttonAdd
             // 
-            this.buttonAdd.Location = new System.Drawing.Point(306, 159);
+            this.buttonAdd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonAdd.Location = new System.Drawing.Point(518, 238);
+            this.buttonAdd.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             this.buttonAdd.Name = "buttonAdd";
-            this.buttonAdd.Size = new System.Drawing.Size(50, 26);
+            this.buttonAdd.Size = new System.Drawing.Size(83, 39);
             this.buttonAdd.TabIndex = 2;
             this.buttonAdd.Text = "追加";
             this.buttonAdd.UseVisualStyleBackColor = true;
             this.buttonAdd.Click += new System.EventHandler(this.ButtonAdd_Click);
             // 
+            // _labelMenmberNum
+            // 
+            this._labelMenmberNum.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this._labelMenmberNum.Location = new System.Drawing.Point(12, 366);
+            this._labelMenmberNum.Name = "_labelMenmberNum";
+            this._labelMenmberNum.Size = new System.Drawing.Size(480, 27);
+            this._labelMenmberNum.TabIndex = 3;
+            // 
             // ManageMemberForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 18F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(369, 225);
+            this.ClientSize = new System.Drawing.Size(623, 404);
+            this.Controls.Add(this._labelMenmberNum);
             this.Controls.Add(this.buttonAdd);
             this.Controls.Add(this.buttonEdit);
             this.Controls.Add(this.buttonDown);
             this.Controls.Add(this.buttonUp);
             this.Controls.Add(this.listBox1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
-            this.Margin = new System.Windows.Forms.Padding(1, 2, 1, 2);
+            this.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.Name = "ManageMemberForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "メンバーの編集";
@@ -121,5 +134,6 @@
         private System.Windows.Forms.Button buttonDown;
         private System.Windows.Forms.Button buttonEdit;
         private System.Windows.Forms.Button buttonAdd;
+        private System.Windows.Forms.Label _labelMenmberNum;
     }
 }

--- a/ProjectsTM.UI.MainForm/ManageMemberForm.Designer.cs
+++ b/ProjectsTM.UI.MainForm/ManageMemberForm.Designer.cs
@@ -48,6 +48,7 @@
             this.listBox1.Name = "listBox1";
             this.listBox1.Size = new System.Drawing.Size(482, 346);
             this.listBox1.TabIndex = 0;
+            this.listBox1.SelectedIndexChanged += new System.EventHandler(this.listBox1_SelectedIndexChanged);
             this.listBox1.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.ListBox1_MouseDoubleClick);
             // 
             // buttonUp

--- a/ProjectsTM.UI.MainForm/ManageMemberForm.cs
+++ b/ProjectsTM.UI.MainForm/ManageMemberForm.cs
@@ -1,10 +1,8 @@
 ﻿using ProjectsTM.Model;
+using ProjectsTM.Service;
 using ProjectsTM.UI.Common;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Forms;
-using ProjectsTM.Service;
 
 namespace ProjectsTM.UI.MainForm
 {
@@ -29,15 +27,6 @@ namespace ProjectsTM.UI.MainForm
             _appData.Members.Up(m);
             UpdateList();
             listBox1.SelectedIndex = index == 0 ? index : index - 1;
-        }
-
-        private void UpdateList()
-        {
-            listBox1.Items.Clear();
-            foreach (var m in _appData.Members)
-            {
-                listBox1.Items.Add(m);
-            }
         }
 
         private void ButtonDown_Click(object sender, EventArgs e)
@@ -90,10 +79,18 @@ namespace ProjectsTM.UI.MainForm
             UpdateList();
             UpdateDiplay();
         }
+        private void UpdateList()
+        {
+            listBox1.Items.Clear();
+            foreach (var m in _appData.Members)
+            {
+                listBox1.Items.Add(m);
+            }
+        }
 
         private void UpdateDiplay()
         {
-            _labelMenmberNum.Text = CountMemberNumService.GetCountStr(_appData);
+            _labelMenmberNum.Text = CountMemberNumService.GetCountStr(_appData.Members);
         }
     }
 }

--- a/ProjectsTM.UI.MainForm/ManageMemberForm.cs
+++ b/ProjectsTM.UI.MainForm/ManageMemberForm.cs
@@ -1,7 +1,10 @@
 ﻿using ProjectsTM.Model;
 using ProjectsTM.UI.Common;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
+using ProjectsTM.Service;
 
 namespace ProjectsTM.UI.MainForm
 {
@@ -15,6 +18,7 @@ namespace ProjectsTM.UI.MainForm
             _appData = appData;
             listBox1.DisplayMember = "NaturalString";
             UpdateList();
+            UpdateDiplay();
         }
 
         private void ButtonUp_Click(object sender, EventArgs e)
@@ -67,13 +71,13 @@ namespace ProjectsTM.UI.MainForm
                 m.EditApply(dlg.EditText);
             }
             UpdateList();
+            UpdateDiplay();
         }
 
         private void ListBox1_MouseDoubleClick(object sender, MouseEventArgs e)
         {
             Edit();
         }
-
         private void ButtonAdd_Click(object sender, EventArgs e)
         {
             using (var dlg = new EditMemberForm((new Member()).ToSerializeString()))
@@ -84,6 +88,12 @@ namespace ProjectsTM.UI.MainForm
                 _appData.Members.Add(after);
             }
             UpdateList();
+            UpdateDiplay();
+        }
+
+        private void UpdateDiplay()
+        {
+            _labelMenmberNum.Text = CountMemberNumService.GetCountStr(_appData);
         }
     }
 }

--- a/ProjectsTM.UI.MainForm/ManageMemberForm.cs
+++ b/ProjectsTM.UI.MainForm/ManageMemberForm.cs
@@ -16,7 +16,7 @@ namespace ProjectsTM.UI.MainForm
             _appData = appData;
             listBox1.DisplayMember = "NaturalString";
             UpdateList();
-            UpdateDiplay();
+            UpdateDisplay();
         }
 
         private void ButtonUp_Click(object sender, EventArgs e)
@@ -27,6 +27,7 @@ namespace ProjectsTM.UI.MainForm
             _appData.Members.Up(m);
             UpdateList();
             listBox1.SelectedIndex = index == 0 ? index : index - 1;
+            UpdateDisplay();
         }
 
         private void ButtonDown_Click(object sender, EventArgs e)
@@ -35,8 +36,8 @@ namespace ProjectsTM.UI.MainForm
             if (m == null) return;
             var index = listBox1.SelectedIndex;
             _appData.Members.Down(m);
-            UpdateList();
             listBox1.SelectedIndex = listBox1.Items.Count == index + 1 ? index : index + 1;
+            UpdateDisplay();
         }
 
         private void ButtonEdit_Click(object sender, EventArgs e)
@@ -60,7 +61,7 @@ namespace ProjectsTM.UI.MainForm
                 m.EditApply(dlg.EditText);
             }
             UpdateList();
-            UpdateDiplay();
+            UpdateDisplay();
         }
 
         private void ListBox1_MouseDoubleClick(object sender, MouseEventArgs e)
@@ -77,7 +78,7 @@ namespace ProjectsTM.UI.MainForm
                 _appData.Members.Add(after);
             }
             UpdateList();
-            UpdateDiplay();
+            UpdateDisplay();
         }
         private void UpdateList()
         {
@@ -87,10 +88,21 @@ namespace ProjectsTM.UI.MainForm
                 listBox1.Items.Add(m);
             }
         }
-
-        private void UpdateDiplay()
+        
+        private void listBox1_SelectedIndexChanged(object sender, EventArgs e)
         {
-            _labelMenmberNum.Text = CountMemberNumService.GetCountStr(_appData.Members);
+            UpdateDisplay();
+        }
+
+        private void UpdateDisplay()
+        {
+            var m = listBox1.SelectedItem as Member;
+            if (m == null)
+            {
+                _labelMenmberNum.Text = "Total:" + _appData.Members.Count.ToString();
+                return;
+            }
+            _labelMenmberNum.Text = CountMemberNumService.GetCountStr(_appData.Members, m.Company);
         }
     }
 }


### PR DESCRIPTION
■ DLG内に合計人数や各所属人数を表示するためのlavelを追加
■ ProjectTM.Serviceに合計人数や各所属人数を数えて文字列で渡すクラスCountMemberNumServiceを追加
■ 表示、編集、追加のタイミングで表示文字列が変更されるようにManageMemberFormを変更

◆追加ボタンにアンカーがついていないバグがあったのでついでに修正。

@松蔭さん
退社済み属性の対応はまだマージされていないのでしょうか？
#22がClose?されていた、Memberクラスにそのようなプロパティがなかったこと
からそのように思ってます。