### PR TITLE
メンバー編集ダイアログのDownボタンでメンバ並び順を変更しても、ダイアログ上のリストへ変更が反映されない問題を修正

### DIFF
--- a/ProjectsTM.UI.MainForm/ManageMemberForm.cs
+++ b/ProjectsTM.UI.MainForm/ManageMemberForm.cs
@@ -36,6 +36,7 @@ namespace ProjectsTM.UI.MainForm
             if (m == null) return;
             var index = listBox1.SelectedIndex;
             _appData.Members.Down(m);
+            UpdateList();
             listBox1.SelectedIndex = listBox1.Items.Count == index + 1 ? index : index + 1;
             UpdateDisplay();
         }


### PR DESCRIPTION
編集後にリスト更新がかかっていなかったので、
更新するよう修正