### PR TITLE
リロードするとAllフィルタに切りわかってしまう問題を修正

### DIFF
--- a/ProjectsTM.Service/FilterComboBoxService.cs
+++ b/ProjectsTM.Service/FilterComboBoxService.cs
@@ -155,7 +155,7 @@ namespace ProjectsTM.Service
             {
                 if (IsMemberMatchText(m, @"^\[.*?]\[.*?]\[.*?\(" + com + @"\)]\[.*?]\[.*?]")) members.Add(m);
             }
-            return new Filter(null, null, members, false, com);
+            return new Filter(null, null, members, false, com, false);
         }
 
         private Filter GetFilterByProjects(ref int idx)
@@ -172,7 +172,7 @@ namespace ProjectsTM.Service
             {
                 if (IsMemberMatchText(m, @"^\[.*?\]\[" + pro.ToString() + @"\]")) members.Add(m);
             }
-            return new Filter(null, null, members, false, pro.ToString());
+            return new Filter(null, null, members, false, pro.ToString(), false);
         }
 
         private Filter GetFilterByFiles(ref int idx)

--- a/ProjectsTM.UI.MainForm/FilterForm.cs
+++ b/ProjectsTM.UI.MainForm/FilterForm.cs
@@ -124,7 +124,7 @@ namespace ProjectsTM.UI.MainForm
 
         public Filter GetFilter()
         {
-            return new Filter(GetWorkItemFilter(), GetPeriodFilter(), GetCheckedMembers(), checkBox_IsFreeTimeMemberShow.Checked, comboBox_MSFiltersSearchPattern.Text);
+            return new Filter(GetWorkItemFilter(), GetPeriodFilter(), GetCheckedMembers(), checkBox_IsFreeTimeMemberShow.Checked, comboBox_MSFiltersSearchPattern.Text, false);
         }
 
         private string GetWorkItemFilter()

--- a/ProjectsTM.ViewModel/Filter.cs
+++ b/ProjectsTM.ViewModel/Filter.cs
@@ -8,13 +8,14 @@ namespace ProjectsTM.ViewModel
     public class Filter : IEquatable<Filter>
     {
         public Filter() { }
-        public Filter(string v, Period period, Members showMembers, bool isFreeTimeMemberShow, string msFilterSearchPattern)
+        public Filter(string v, Period period, Members showMembers, bool isFreeTimeMemberShow, string msFilterSearchPattern, bool isAllFilter)
         {
             if (v != null) WorkItem = v;
             if (period != null) Period = period;
             if (showMembers != null) ShowMembers = showMembers;
             IsFreeTimeMemberShow = isFreeTimeMemberShow;
             if (MSFilterSearchPattern != null) MSFilterSearchPattern = msFilterSearchPattern;
+            IsAllFilter = isAllFilter;
         }
 
         public void SetShowMemersFromHideMembers(List<Member> allMembers) //TODO:HideMembersが撲滅されたら消す
@@ -30,7 +31,9 @@ namespace ProjectsTM.ViewModel
         public string WorkItem { get; set; } = string.Empty;
         public bool IsFreeTimeMemberShow { get; set; } = true;
         public string MSFilterSearchPattern { get; set; } = "ALL";
-        public static Filter All(ViewData viewData) => new Filter(null, null, viewData != null ? viewData.Original.Members : new Members(), false, "ALL");
+        public static Filter All(ViewData viewData) => new Filter(null, null, viewData != null ? viewData.Original.Members : new Members(), false, "ALL", true);
+
+        public bool IsAllFilter { get; set; } = false;
 
         public bool Equals(Filter other)
         {

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -17,9 +17,15 @@ namespace ProjectsTM.ViewModel
         {
             _appData = appData;
             UndoService = undoService;
-            this.Filter = Filter.All(this);
+            UpdateAllFilter();
             RemoveFreeTimeMembersFromFilter();
             AppDataChanged?.Invoke(this, null);
+        }
+
+        private void UpdateAllFilter()
+        {
+            if (!this.Filter.IsAllFilter) return;
+            this.Filter = Filter.All(this);
         }
 
         private AppData _appData;

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -17,12 +17,12 @@ namespace ProjectsTM.ViewModel
         {
             _appData = appData;
             UndoService = undoService;
-            UpdateAllFilter();
+            UpdateFilter();
             RemoveFreeTimeMembersFromFilter();
             AppDataChanged?.Invoke(this, null);
         }
 
-        private void UpdateAllFilter()
+        private void UpdateFilter()
         {
             if (!this.Filter.IsAllFilter) return;
             this.Filter = Filter.All(this);


### PR DESCRIPTION
■ViewData.cs
・SetAppData( )内のALLフィルタ更新を、ALLフィルタ設定時のみ更新するよう修正
　（常にALLフィルタの更新していた。
　　ALLフィルタ設定時は、showMembersを更新する必要があるため、
　　ALLフィルタ設定時の更新は残す）

■Filter.cs
・「ViewData.Filterに設定されたフィルタが、ALLフィルタとして設定されたものか」
　を識別するフラグ（IsAllFilter）を追加。これをコンストラクタの引数に追加

■その他ファイル
・Filterコンストラクタの変更へ追従
　