### PR TITLE
タスクリストの列順を変更

### DIFF
--- a/ProjectsTM.UI.TaskList/ColDefinition.cs
+++ b/ProjectsTM.UI.TaskList/ColDefinition.cs
@@ -1,0 +1,87 @@
+﻿using FreeGridControl;
+using ProjectsTM.ViewModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ProjectsTM.UI.TaskList
+{
+    class ColDefinition
+    {
+        public static int Count => 10;
+
+        public static ColIndex InitialSortCol => new ColIndex(7);
+
+        public static string GetTitle(ColIndex c)
+        {
+            string[] titles = new string[] { "名前", "エラー", "プロジェクト", "担当", "タグ", "状態", "開始", "終了", "人日", "備考" };
+            return titles[c.Value];
+        }
+
+        public static string GetText(TaskListItem item, ColIndex c, ViewData viewData)
+        {
+            var colIndex = c.Value;
+            var wi = item.WorkItem;
+            if (colIndex == 0)
+            {
+                return wi.Name;
+            }
+            else if (colIndex == 1)
+            {
+                return item.ErrMsg;
+            }
+            else if (colIndex == 2)
+            {
+                return wi.Project.ToString();
+            }
+            else if (colIndex == 3)
+            {
+                return wi.AssignedMember.ToString();
+            }
+            else if (colIndex == 4)
+            {
+                return wi.Tags.ToString();
+            }
+            else if (colIndex == 5)
+            {
+                return wi.State.ToString();
+            }
+            else if (colIndex == 6)
+            {
+                return wi.Period.From.ToString();
+            }
+            else if (colIndex == 7)
+            {
+                return wi.Period.To.ToString();
+            }
+            else if (colIndex == 8)
+            {
+                return viewData.Original.Callender.GetPeriodDayCount(wi.Period).ToString();
+            }
+            else if (colIndex == 9)
+            {
+                return wi.Description;
+            }
+            return string.Empty;
+        }
+
+        private static bool IsDayCountCol(ColIndex c)
+        {
+            return c.Value == 8;
+        }
+
+        internal static void Sort(ColIndex sortCol, List<TaskListItem> listItems, ViewData viewData)
+        {
+            if (IsDayCountCol(sortCol))
+            {
+                listItems = listItems.OrderBy(l => viewData.Original.Callender.GetPeriodDayCount(l.WorkItem.Period)).ToList();
+            }
+            else
+            {
+                listItems = listItems.OrderBy(l => GetText(l, sortCol, viewData)).ToList();
+            }
+        }
+    }
+}

--- a/ProjectsTM.UI.TaskList/ColDefinition.cs
+++ b/ProjectsTM.UI.TaskList/ColDefinition.cs
@@ -12,6 +12,8 @@ namespace ProjectsTM.UI.TaskList
 
         public static ColIndex InitialSortCol => ToIndex(ColIds.End);
 
+        public static ColIndex AutoExtendCol => ToIndex(ColIds.Description);
+
         private static Dictionary<ColIds, ColSpecification> _colTable = new Dictionary<ColIds, ColSpecification>() {
             {ColIds.Name, new ColSpecification("名前", (i,cal)=>i.WorkItem.Name) },
             {ColIds.Error, new ColSpecification("エラー", (i, cal) => i.ErrMsg) },
@@ -22,7 +24,7 @@ namespace ProjectsTM.UI.TaskList
             {ColIds.Start, new ColSpecification( "開始", (i, cal) => i.WorkItem.Period.From.ToString()) },
             {ColIds.End, new ColSpecification( "終了", (i, cal) => i.WorkItem.Period.To.ToString()) },
             {ColIds.DayCount, new ColSpecification( "人日", (i, cal) =>  cal.GetPeriodDayCount(i.WorkItem.Period).ToString())},
-            {ColIds.Desktiprion, new ColSpecification( "備考", (i, cal) => i.WorkItem.Description) },
+            {ColIds.Description, new ColSpecification( "備考", (i, cal) => i.WorkItem.Description) },
         };
 
         public static string GetTitle(ColIndex c)
@@ -48,7 +50,7 @@ namespace ProjectsTM.UI.TaskList
 
         private static bool IsDayCountCol(ColIndex c)
         {
-            return c.Value == 8;
+            return ToIndex(ColIds.DayCount).Equals(c);
         }
 
         internal static void Sort(ColIndex sortCol, List<TaskListItem> listItems, ViewData viewData)

--- a/ProjectsTM.UI.TaskList/ColDefinition.cs
+++ b/ProjectsTM.UI.TaskList/ColDefinition.cs
@@ -3,68 +3,47 @@ using ProjectsTM.ViewModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ProjectsTM.UI.TaskList
 {
     class ColDefinition
     {
-        public static int Count => 10;
+        public static int Count => Enum.GetNames(typeof(ColIds)).Count();
 
-        public static ColIndex InitialSortCol => new ColIndex(7);
+        public static ColIndex InitialSortCol => ToIndex(ColIds.End);
+
+        private static Dictionary<ColIds, ColSpecification> _colTable = new Dictionary<ColIds, ColSpecification>() {
+            {ColIds.Name, new ColSpecification("名前", (i,cal)=>i.WorkItem.Name) },
+            {ColIds.Error, new ColSpecification("エラー", (i, cal) => i.ErrMsg) },
+            {ColIds.Project, new ColSpecification( "プロジェクト", (i, cal) => i.WorkItem.Project.ToString()) },
+            {ColIds.Assign, new ColSpecification( "担当", (i, cal) => i.WorkItem.AssignedMember.ToString()) },
+            {ColIds.Tag, new ColSpecification( "タグ", (i, cal) => i.WorkItem.Tags.ToString()) },
+            {ColIds.State, new ColSpecification( "状態", (i,cal) => i.WorkItem.State.ToString())},
+            {ColIds.Start, new ColSpecification( "開始", (i, cal) => i.WorkItem.Period.From.ToString()) },
+            {ColIds.End, new ColSpecification( "終了", (i, cal) => i.WorkItem.Period.To.ToString()) },
+            {ColIds.DayCount, new ColSpecification( "人日", (i, cal) =>  cal.GetPeriodDayCount(i.WorkItem.Period).ToString())},
+            {ColIds.Desktiprion, new ColSpecification( "備考", (i, cal) => i.WorkItem.Description) },
+        };
 
         public static string GetTitle(ColIndex c)
         {
-            string[] titles = new string[] { "名前", "エラー", "プロジェクト", "担当", "タグ", "状態", "開始", "終了", "人日", "備考" };
-            return titles[c.Value];
+            return _colTable[ToId(c)].Title;
+        }
+
+        private static ColIndex ToIndex(ColIds id)
+        {
+            var idx = (int)id;
+            return new ColIndex(idx);
+        }
+
+        private static ColIds ToId(ColIndex c)
+        {
+            return (ColIds)c.Value;
         }
 
         public static string GetText(TaskListItem item, ColIndex c, ViewData viewData)
         {
-            var colIndex = c.Value;
-            var wi = item.WorkItem;
-            if (colIndex == 0)
-            {
-                return wi.Name;
-            }
-            else if (colIndex == 1)
-            {
-                return item.ErrMsg;
-            }
-            else if (colIndex == 2)
-            {
-                return wi.Project.ToString();
-            }
-            else if (colIndex == 3)
-            {
-                return wi.AssignedMember.ToString();
-            }
-            else if (colIndex == 4)
-            {
-                return wi.Tags.ToString();
-            }
-            else if (colIndex == 5)
-            {
-                return wi.State.ToString();
-            }
-            else if (colIndex == 6)
-            {
-                return wi.Period.From.ToString();
-            }
-            else if (colIndex == 7)
-            {
-                return wi.Period.To.ToString();
-            }
-            else if (colIndex == 8)
-            {
-                return viewData.Original.Callender.GetPeriodDayCount(wi.Period).ToString();
-            }
-            else if (colIndex == 9)
-            {
-                return wi.Description;
-            }
-            return string.Empty;
+            return _colTable[ToId(c)].GetText(item, viewData.Original.Callender);
         }
 
         private static bool IsDayCountCol(ColIndex c)

--- a/ProjectsTM.UI.TaskList/ColIds.cs
+++ b/ProjectsTM.UI.TaskList/ColIds.cs
@@ -11,6 +11,6 @@
         Start,
         End,
         DayCount,
-        Desktiprion,
+        Description,
     }
 }

--- a/ProjectsTM.UI.TaskList/ColIds.cs
+++ b/ProjectsTM.UI.TaskList/ColIds.cs
@@ -1,0 +1,16 @@
+﻿namespace ProjectsTM.UI.TaskList
+{
+    enum ColIds
+    {
+        Name,
+        Error,
+        Project,
+        Assign,
+        Tag,
+        State,
+        Start,
+        End,
+        DayCount,
+        Desktiprion,
+    }
+}

--- a/ProjectsTM.UI.TaskList/ColSpecification.cs
+++ b/ProjectsTM.UI.TaskList/ColSpecification.cs
@@ -1,0 +1,17 @@
+﻿using ProjectsTM.Model;
+using System;
+
+namespace ProjectsTM.UI.TaskList
+{
+    class ColSpecification
+    {
+        public string Title;
+        public Func<TaskListItem, Callender, string> GetText;
+
+        public ColSpecification(string title, Func<TaskListItem, Callender, string> getText)
+        {
+            Title = title;
+            GetText = getText;
+        }
+    }
+}

--- a/ProjectsTM.UI.TaskList/ProjectsTM.UI.TaskList.csproj
+++ b/ProjectsTM.UI.TaskList/ProjectsTM.UI.TaskList.csproj
@@ -45,6 +45,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ColDefinition.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TaskListForm.cs">
       <SubType>Form</SubType>

--- a/ProjectsTM.UI.TaskList/ProjectsTM.UI.TaskList.csproj
+++ b/ProjectsTM.UI.TaskList/ProjectsTM.UI.TaskList.csproj
@@ -46,6 +46,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ColDefinition.cs" />
+    <Compile Include="ColIds.cs" />
+    <Compile Include="ColSpecification.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TaskListForm.cs">
       <SubType>Form</SubType>

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -23,7 +23,7 @@ namespace ProjectsTM.UI.TaskList
         private WorkItemEditService _editService;
 
         public event EventHandler ListUpdated;
-        private ColIndex _sortCol = new ColIndex(6);
+        private ColIndex _sortCol = ColDefinition.InitialSortCol;
         private bool _isReverse = false;
         private RowIndex _lastSelect;
         private WidthAdjuster _widthAdjuster;
@@ -215,23 +215,11 @@ namespace ProjectsTM.UI.TaskList
 
         private void Sort()
         {
-            if (IsDayCountCol(_sortCol))
-            {
-                _listItems = _listItems.OrderBy(l => _viewData.Original.Callender.GetPeriodDayCount(l.WorkItem.Period)).ToList();
-            }
-            else
-            {
-                _listItems = _listItems.OrderBy(l => GetText(l, _sortCol)).ToList();
-            }
+            ColDefinition.Sort(_sortCol, _listItems, _viewData);
             if (_isReverse)
             {
                 _listItems.Reverse();
             }
-        }
-
-        private static bool IsDayCountCol(ColIndex c)
-        {
-            return c.Value == 7;
         }
 
         private void TaskListGrid_Disposed(object sender, EventArgs e)
@@ -283,7 +271,7 @@ namespace ProjectsTM.UI.TaskList
         {
             LockUpdate = true;
             UpdateListItem();
-            ColCount = 10;
+            ColCount = ColDefinition.Count;
             FixedRowCount = 1;
             RowCount = _listItems.Count + FixedRowCount;
             InitializeColWidth();
@@ -444,7 +432,7 @@ namespace ProjectsTM.UI.TaskList
 
         private bool IsTooBig(WorkItem wi)
         {
-            return 10 < _viewData.Original.Callender.GetPeriodDayCount(wi.Period);
+            return ColDefinition.Count < _viewData.Original.Callender.GetPeriodDayCount(wi.Period);
         }
 
         private bool IsStartSoon(WorkItem wi, CallenderDay soon)
@@ -521,7 +509,7 @@ namespace ProjectsTM.UI.TaskList
                 if (!res.HasValue) continue;
                 g.FillRectangle(BrushCache.GetBrush(item.Color), res.Value.Value);
                 g.DrawRectangle(Pens.Black, Rectangle.Round(res.Value.Value));
-                var text = GetText(item, c);
+                var text = ColDefinition.GetText(item, c, _viewData);
                 var rect = res.Value;
                 rect.Y += 1;
                 g.DrawString(text, this.Font, Brushes.Black, rect.Value, format);
@@ -536,52 +524,6 @@ namespace ProjectsTM.UI.TaskList
             }
         }
 
-        private string GetText(TaskListItem item, ColIndex c)
-        {
-            var colIndex = c.Value;
-            var wi = item.WorkItem;
-            if (colIndex == 0)
-            {
-                return wi.Name;
-            }
-            else if (colIndex == 1)
-            {
-                return wi.Project.ToString();
-            }
-            else if (colIndex == 2)
-            {
-                return wi.AssignedMember.ToString();
-            }
-            else if (colIndex == 3)
-            {
-                return wi.Tags.ToString();
-            }
-            else if (colIndex == 4)
-            {
-                return wi.State.ToString();
-            }
-            else if (colIndex == 5)
-            {
-                return wi.Period.From.ToString();
-            }
-            else if (colIndex == 6)
-            {
-                return wi.Period.To.ToString();
-            }
-            else if (colIndex == 7)
-            {
-                return _viewData.Original.Callender.GetPeriodDayCount(wi.Period).ToString();
-            }
-            else if (colIndex == 8)
-            {
-                return wi.Description;
-            }
-            else if (colIndex == 9)
-            {
-                return item.ErrMsg;
-            }
-            return string.Empty;
-        }
 
         private void DrawTitleRow(Graphics g)
         {
@@ -596,16 +538,10 @@ namespace ProjectsTM.UI.TaskList
                     g.DrawRectangle(Pens.Black, res.Value.Value);
                     var rect = res.Value;
                     rect.Y += 1;
-                    g.DrawString(GetTitle(c), this.Font, Brushes.Black, rect.Value);
+                    g.DrawString(ColDefinition.GetTitle(c), this.Font, Brushes.Black, rect.Value);
                     if (c.Equals(_sortCol)) g.DrawString(_isReverse ? "▼" : "▲", this.Font, Brushes.Black, rect.Value, format);
                 }
             }
-        }
-
-        private static string GetTitle(ColIndex c)
-        {
-            string[] titles = new string[] { "名前", "プロジェクト", "担当", "タグ", "状態", "開始", "終了", "人日", "備考", "エラー" };
-            return titles[c.Value];
         }
     }
 }

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -326,7 +326,7 @@ namespace ProjectsTM.UI.TaskList
             this.Invalidate();
         }
 
-        private readonly ColIndex AutoExtendCol = new ColIndex(8);
+        private readonly ColIndex AutoExtendCol = ColDefinition.AutoExtendCol;
 
         private void UpdateExtendColWidth()
         {


### PR DESCRIPTION
列幅自動調整列は右端にしないと、列幅変更中の自動更新が整合性取れないので、備考列を右端に変更。
それに伴い、列定義関連の実装を整理。