### PR TITLE
前回終了時が最大化状態だったら復元する機能を追加しました。

### DIFF
--- a/ProjectsTM.Service/FormSizeRestoreService.cs
+++ b/ProjectsTM.Service/FormSizeRestoreService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Windows.Forms;
 using System.Xml.Linq;
 
 namespace ProjectsTM.Service
@@ -31,6 +32,21 @@ namespace ProjectsTM.Service
             {
             }
             return new Size(DEFAULT_WIDTH, DEFAULT_HEIGHT);
+        }
+        
+        public static FormWindowState LoadLastTimeFormState(string form)
+        {
+            try
+            {
+                var xml = XElement.Load(SizeInfoPath);
+                var sizeInfo = xml.Elements(form).Single();
+                var lastTimeStateStr = sizeInfo.Element("lastTimeFormState").Value;
+                if (lastTimeStateStr.Equals("Maximized")) return FormWindowState.Maximized;
+            }
+            catch
+            {
+            }
+            return FormWindowState.Normal;
         }
 
         public static int[] LoadColWidths(string form)
@@ -78,6 +94,15 @@ namespace ProjectsTM.Service
             var widthElement = GetSubElement(formElement, "width");
             heightElement.Value = height.ToString();
             widthElement.Value = width.ToString();
+            root.Save(SizeInfoPath);
+        }
+
+        public static void SaveFormState(FormWindowState state, string form)
+        {
+            var root = GetRootElement(SizeInfoPath);
+            var formElement = GetSubElement(root, form);
+            var lastTimeFormState = GetSubElement(formElement, "lastTimeFormState");
+            lastTimeFormState.Value = state.ToString();
             root.Save(SizeInfoPath);
         }
 

--- a/ProjectsTM.UI.MainForm/MainForm.cs
+++ b/ProjectsTM.UI.MainForm/MainForm.cs
@@ -59,7 +59,18 @@ namespace ProjectsTM.UI.MainForm
 
         private void MainForm_Load(object sender, EventArgs e)
         {
-            Size = FormSizeRestoreService.LoadFormSize("MainFormSize");
+            FormWindowState state;
+            state = FormSizeRestoreService.LoadLastTimeFormState("MainFormState");
+
+            switch (state) 
+            {
+                case FormWindowState.Maximized:
+                    this.WindowState = state;
+                    break;
+                case FormWindowState.Normal:
+                    Size = FormSizeRestoreService.LoadFormSize("MainFormSize");
+                    break;
+            }
         }
 
         private async void _timer_Tick(object sender, EventArgs e)
@@ -190,6 +201,7 @@ namespace ProjectsTM.UI.MainForm
             };
             UserSettingUIService.Save(setting);
             FormSizeRestoreService.SaveFormSize(Height, Width, "MainFormSize");
+            FormSizeRestoreService.SaveFormState(this.WindowState, "MainFormState");
         }
 
         private void InitializeViewData()


### PR DESCRIPTION
■ FormSizeRestoreServiceにメソッド追加
　LoadLastTimeFormState
    ->前回の終了時のWIndowStateを読みだす。
　SaveFormState
     ->終了時のWindowStateを保存
■ MainFormの初期サイズ決定ロジックを変更
　　前回サイズがMaxmizedならそれを再現、Normalなら閉じたときのサイズを再現。