### PR TITLE
マイルストーンにマウスオーバしたときに、マイルストンをツールチップに表示するよう追加

### DIFF
--- a/ProjectsTM.Service/KeyAndMouseHandleService.cs
+++ b/ProjectsTM.Service/KeyAndMouseHandleService.cs
@@ -167,10 +167,19 @@ namespace ProjectsTM.Service
         private void UpdateHoveringText(ClientPoint location)
         {
             if (_workItemDragService.IsActive()) return;
-            if (_grid.IsFixedArea(location)) { _toolTipService.Hide(); return; }
+            if (_grid.IsFixedArea(location)) { UpdateHoveringMileStoneText(location); return; }
             RawPoint cur = _grid.Client2Raw(location);
             var wi = _viewData.PickFilterdWorkItem(_grid.X2Member(cur.X), _grid.Y2Day(cur.Y));
             HoveringTextChanged?.Invoke(this, wi);
+        }
+
+        private void UpdateHoveringMileStoneText(ClientPoint location)
+        {
+            var day = _grid.Y2Day(_grid.Client2Raw(location).Y);
+            if (day == null) { _toolTipService.Hide(); return; }
+            var ms = _viewData.Original.MileStones.Where(m => day.Equals(m.Day));
+            if (ms.Count() == 0) { _toolTipService.Hide(); return; }
+            _toolTipService.Update(day, ms);
         }
 
         public void DoubleClick(MouseEventArgs e)

--- a/ProjectsTM.Service/ToolTipService.cs
+++ b/ProjectsTM.Service/ToolTipService.cs
@@ -1,6 +1,7 @@
 ﻿using ProjectsTM.Model;
 using ProjectsTM.ViewModel;
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Windows.Forms;
 
@@ -76,6 +77,15 @@ namespace ProjectsTM.Service
         {
             if (wi == null) { this.Hide(); return; }
             string s = CreateStrForTooltip(wi, days);
+            if (!s.Equals(_toolTip.GetToolTip(_parentControl))) _toolTip.SetToolTip(_parentControl, s);
+        }
+
+        public void Update(CallenderDay day, IEnumerable<MileStone> ms)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine(day.ToString());
+            foreach (var m in ms) sb.AppendLine(m.Name);
+            string s = sb.ToString();
             if (!s.Equals(_toolTip.GetToolTip(_parentControl))) _toolTip.SetToolTip(_parentControl, s);
         }
 


### PR DESCRIPTION
マイルストーンが見にくい問題の対策。

マイルストーンへマウスオーバしたときに、マイルストーンをツールチップ表示するよう追加。
同一日に複数マイルストン存在する場合は、複数行表示。

★対策として足りなそうであれば、別案試すので、教えてください。