### PR TITLE
タスクリストでMSをダブルクリックから編集可能にする対応

### DIFF
--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -247,7 +247,21 @@ namespace ProjectsTM.UI.TaskList
             var r = Y2Row(Client2Raw(ClientPoint.Create(e)).Y);
             if (r.Value < FixedRowCount) return;
             var item = _listItems[r.Value - FixedRowCount];
-            if (item.IsMilestone) return;
+
+            if (item.IsMilestone)
+            {
+                var selectMs = _viewData.Original.MileStones.Where(x => x.Name.Equals(item.WorkItem.Name) && x.Project.Equals(item.WorkItem.Project)).First();
+                using (var dlg = new EditMileStoneForm(_viewData.Original.Callender, selectMs, _viewData.Original.MileStones.GetMileStoneFilters()))
+                {
+                    if (dlg.ShowDialog() != DialogResult.OK) return;
+                    _viewData.Original.MileStones.Replace(selectMs, dlg.MileStone);
+                    var newWi = ConvertWorkItem(dlg.MileStone);
+                    _viewData.UpdateCallender(newWi);
+                    _listItems[r.Value - FixedRowCount].WorkItem = newWi;
+                    UpdateView();
+                    return;
+                }
+            }
             using (var dlg = new EditWorkItemForm(item.WorkItem.Clone(), _viewData.Original.WorkItems, _viewData.Original.Callender, _viewData.GetFilteredMembers()))
             {
                 if (dlg.ShowDialog() != DialogResult.OK) return;

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -250,7 +250,7 @@ namespace ProjectsTM.UI.TaskList
 
             if (item.IsMilestone)
             {
-                var selectMs = _viewData.Original.MileStones.Where(x => x.Name.Equals(item.WorkItem.Name) && x.Project.Equals(item.WorkItem.Project)).First();
+                var selectMs = _viewData.Original.MileStones.Where(x => item.Equals(x)).First();
                 using (var dlg = new EditMileStoneForm(_viewData.Original.Callender, selectMs, _viewData.Original.MileStones.GetMileStoneFilters()))
                 {
                     if (dlg.ShowDialog() != DialogResult.OK) return;

--- a/ProjectsTM.UI.TaskList/TaskListGrid.cs
+++ b/ProjectsTM.UI.TaskList/TaskListGrid.cs
@@ -250,13 +250,12 @@ namespace ProjectsTM.UI.TaskList
 
             if (item.IsMilestone)
             {
-                var selectMs = _viewData.Original.MileStones.Where(x => item.Equals(x)).First();
+                var selectMs = item.MileStone;
                 using (var dlg = new EditMileStoneForm(_viewData.Original.Callender, selectMs, _viewData.Original.MileStones.GetMileStoneFilters()))
                 {
                     if (dlg.ShowDialog() != DialogResult.OK) return;
                     _viewData.Original.MileStones.Replace(selectMs, dlg.MileStone);
                     var newWi = ConvertWorkItem(dlg.MileStone);
-                    _viewData.UpdateCallender(newWi);
                     _listItems[r.Value - FixedRowCount].WorkItem = newWi;
                     UpdateView();
                     return;
@@ -482,7 +481,7 @@ namespace ProjectsTM.UI.TaskList
             {
                 if (!IsMatchPattern(wi.ToString())) continue;
                 audit.TryGetValue(wi, out string error);
-                list.Add(new TaskListItem(wi, GetColor(wi.State, error), false, error));
+                list.Add(new TaskListItem(wi, GetColor(wi.State, error), error));
             }
             if (Option.IsShowMS)
             {
@@ -490,7 +489,7 @@ namespace ProjectsTM.UI.TaskList
                 {
                     var wi = ConvertWorkItem(ms);
                     if (!IsMatchPattern(wi.ToString())) continue;
-                    list.Add(new TaskListItem(wi, ms.Color, true, string.Empty));
+                    list.Add(new TaskListItem(wi, ms, ms.Color, string.Empty));
                 }
             }
             return list;

--- a/ProjectsTM.UI.TaskList/TaskListItem.cs
+++ b/ProjectsTM.UI.TaskList/TaskListItem.cs
@@ -5,28 +5,28 @@ namespace ProjectsTM.UI.TaskList
 {
     internal class TaskListItem
     {
-        public TaskListItem(WorkItem w, Color color, bool isMilestone, string errMsg)
+        public TaskListItem(WorkItem w, Color color, string errMsg)
         {
             this.WorkItem = w;
             this.Color = color;
-            IsMilestone = isMilestone;
+            IsMilestone = false;
+            ErrMsg = string.IsNullOrEmpty(errMsg) ? string.Empty : errMsg;
+        }
+
+        public TaskListItem(WorkItem w, MileStone mileStone, Color color, string errMsg)
+        {
+            this.WorkItem = w;
+            this.Color = color;
+            this.MileStone = mileStone;
+            IsMilestone = true;
             ErrMsg = string.IsNullOrEmpty(errMsg) ? string.Empty : errMsg;
         }
 
         public WorkItem WorkItem { get;  internal set; }
+
+        public MileStone MileStone { get; set; }
         public Color Color { get; private set; }
         public bool IsMilestone { get; internal set; }
         public string ErrMsg { get; }
-
-        public bool Equals(MileStone ms)
-        {
-            if (!IsMilestone) return false;
-            if (WorkItem.Name != ms.Name) return false;
-            if (WorkItem.Period.From != ms.Day) return false;
-            if (WorkItem.Period.To != ms.Day) return false;
-            if (WorkItem.Project != ms.Project) return false;
-            if (WorkItem.State != ms.State) return false;
-            return true;
-        }
     }
 }

--- a/ProjectsTM.UI.TaskList/TaskListItem.cs
+++ b/ProjectsTM.UI.TaskList/TaskListItem.cs
@@ -13,7 +13,7 @@ namespace ProjectsTM.UI.TaskList
             ErrMsg = string.IsNullOrEmpty(errMsg) ? string.Empty : errMsg;
         }
 
-        public WorkItem WorkItem { get; private set; }
+        public WorkItem WorkItem { get;  internal set; }
         public Color Color { get; private set; }
         public bool IsMilestone { get; internal set; }
         public string ErrMsg { get; }

--- a/ProjectsTM.UI.TaskList/TaskListItem.cs
+++ b/ProjectsTM.UI.TaskList/TaskListItem.cs
@@ -17,5 +17,16 @@ namespace ProjectsTM.UI.TaskList
         public Color Color { get; private set; }
         public bool IsMilestone { get; internal set; }
         public string ErrMsg { get; }
+
+        public bool Equals(MileStone ms)
+        {
+            if (!IsMilestone) return false;
+            if (WorkItem.Name != ms.Name) return false;
+            if (WorkItem.Period.From != ms.Day) return false;
+            if (WorkItem.Period.To != ms.Day) return false;
+            if (WorkItem.Project != ms.Project) return false;
+            if (WorkItem.State != ms.State) return false;
+            return true;
+        }
     }
 }

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -219,11 +219,16 @@ namespace ProjectsTM.ViewModel
 
         public void UpdateCallenderAndMembers(WorkItem wi)
         {
+            UpdateCallender(wi);
+            if (!Original.Members.Contains(wi.AssignedMember)) Original.Members.Add(wi.AssignedMember);
+        }
+
+        public void UpdateCallender(WorkItem wi)
+        {
             var days = Original.Callender.Days;
             if (!days.Contains(wi.Period.From)) days.Add(wi.Period.From);
             if (!days.Contains(wi.Period.To)) days.Add(wi.Period.To);
             days.Sort();
-            if (!Original.Members.Contains(wi.AssignedMember)) Original.Members.Add(wi.AssignedMember);
         }
 
         public void DecRatio()

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -219,16 +219,11 @@ namespace ProjectsTM.ViewModel
 
         public void UpdateCallenderAndMembers(WorkItem wi)
         {
-            UpdateCallender(wi);
-            if (!Original.Members.Contains(wi.AssignedMember)) Original.Members.Add(wi.AssignedMember);
-        }
-
-        public void UpdateCallender(WorkItem wi)
-        {
             var days = Original.Callender.Days;
             if (!days.Contains(wi.Period.From)) days.Add(wi.Period.From);
             if (!days.Contains(wi.Period.To)) days.Add(wi.Period.To);
             days.Sort();
+            if (!Original.Members.Contains(wi.AssignedMember)) Original.Members.Add(wi.AssignedMember);
         }
 
         public void DecRatio()


### PR DESCRIPTION
■ TaskListGridでMSの行をダブルクリックするとEditMileStoneFormを呼ぶように変更。
    クリックしたMSを特定するロジックは同じプロジェクト内で同じ名前のMSはない。
　このロジックで対象のMSを取得する。TaskListGridの253行目。

■ EditMileStoneFormで編集後元データ(viewData.Original)を編集後のMSと置換。
　
■ Grid内のデータも書き直す。