### PR TITLE
taskListのエラーソートを逆にする対応

### DIFF
--- a/ProjectsTM.UI.TaskList/ColDefinition.cs
+++ b/ProjectsTM.UI.TaskList/ColDefinition.cs
@@ -66,8 +66,6 @@ namespace ProjectsTM.UI.TaskList
             }
             else if (IsErrorCol(sortCol))
             {
-                var te = GetText(listItems[0], sortCol, viewData);
-                var temp = GetText(listItems[3], sortCol, viewData);
                 listItems = listItems.OrderByDescending(l => GetText(l, sortCol, viewData)).ToList();
             }
             else

--- a/ProjectsTM.UI.TaskList/ColDefinition.cs
+++ b/ProjectsTM.UI.TaskList/ColDefinition.cs
@@ -53,11 +53,22 @@ namespace ProjectsTM.UI.TaskList
             return ToIndex(ColIds.DayCount).Equals(c);
         }
 
+        private static bool IsErrorCol(ColIndex c)
+        {
+            return ToIndex(ColIds.Error).Equals(c);
+        }
+
         internal static void Sort(ColIndex sortCol, ref List<TaskListItem> listItems, ViewData viewData)
         {
             if (IsDayCountCol(sortCol))
             {
                 listItems = listItems.OrderBy(l => viewData.Original.Callender.GetPeriodDayCount(l.WorkItem.Period)).ToList();
+            }
+            else if (IsErrorCol(sortCol))
+            {
+                var te = GetText(listItems[0], sortCol, viewData);
+                var temp = GetText(listItems[3], sortCol, viewData);
+                listItems = listItems.OrderByDescending(l => GetText(l, sortCol, viewData)).ToList();
             }
             else
             {


### PR DESCRIPTION
■ ColDefinition.Sortを変更
ソート列がエラーの時だけ逆向きでソートするようにした。