### PR TITLE
ManagementWokingDaysFormのリファクタリング

### DIFF
--- a/ProjectsTM.Model/Callender.cs
+++ b/ProjectsTM.Model/Callender.cs
@@ -21,6 +21,13 @@ namespace ProjectsTM.Model
             }
         }
 
+        public void UpdateDays(object sender, IEnumerable<CallenderDay> days)
+        {
+            Days = new List<CallenderDay>();
+            foreach (var d in days) Days.Add(d);
+            _nearestDayCache.Clear();
+        }
+
         public void Delete(CallenderDay d)
         {
             Days.Remove(d);

--- a/ProjectsTM.UI.MainForm/MainForm.cs
+++ b/ProjectsTM.UI.MainForm/MainForm.cs
@@ -350,7 +350,7 @@ namespace ProjectsTM.UI.MainForm
 
         private void ToolStripMenuItemWorkingDas_Click(object sender, EventArgs e)
         {
-            using (var dlg = new ManagementWokingDaysForm(_viewData.Original.Callender, _viewData.Original.WorkItems))
+            using (var dlg = new ManagementWokingDaysForm(_viewData.Original.Callender, _viewData.Original.WorkItems, _viewData.Original.Callender.UpdateDays))
             {
                 dlg.ShowDialog();
                 workItemGrid1.Initialize(_viewData);

--- a/ProjectsTM.UI.MainForm/MainForm.cs
+++ b/ProjectsTM.UI.MainForm/MainForm.cs
@@ -350,7 +350,7 @@ namespace ProjectsTM.UI.MainForm
 
         private void ToolStripMenuItemWorkingDas_Click(object sender, EventArgs e)
         {
-            using (var dlg = new ManagementWokingDaysForm(_viewData.Original.Callender, _viewData.Original.WorkItems, _viewData.Original.Callender.UpdateDays))
+            using (var dlg = new ManagementWokingDaysForm(_viewData.Original.Callender, _viewData.Original.Callender.UpdateDays, _viewData.IsDeletable))
             {
                 dlg.ShowDialog();
                 workItemGrid1.Initialize(_viewData);

--- a/ProjectsTM.UI.MainForm/ManagementWokingDaysForm.cs
+++ b/ProjectsTM.UI.MainForm/ManagementWokingDaysForm.cs
@@ -11,7 +11,6 @@ namespace ProjectsTM.UI.MainForm
     public partial class ManagementWokingDaysForm : BaseForm
     {
         private List<CallenderDay> _days;
-        private readonly WorkItems _workItems;
         private event EventHandler<IEnumerable<CallenderDay>> UpdateWokingDays;
         private Func<CallenderDay, bool> IsDeletableWokingDay;
 

--- a/ProjectsTM.UI.MainForm/ManagementWokingDaysForm.cs
+++ b/ProjectsTM.UI.MainForm/ManagementWokingDaysForm.cs
@@ -13,13 +13,18 @@ namespace ProjectsTM.UI.MainForm
         private List<CallenderDay> _days;
         private readonly WorkItems _workItems;
         private event EventHandler<IEnumerable<CallenderDay>> UpdateWokingDays;
-        public ManagementWokingDaysForm(Callender callender, WorkItems workItems, EventHandler<IEnumerable<CallenderDay>> updateWokinggDays)
+        private Func<CallenderDay, bool> IsDeletableWokingDay;
+
+        public ManagementWokingDaysForm(
+            Callender callender, 
+            EventHandler<IEnumerable<CallenderDay>> updateWokinggDays, 
+            Func<CallenderDay, bool> isDeletableWokingDay)
         {
             InitializeComponent();
             this._days = new List<CallenderDay>();
             foreach (var d in callender.Days) _days.Add(d);
-            this._workItems = workItems;
             this.UpdateWokingDays += updateWokinggDays;
+            this.IsDeletableWokingDay += isDeletableWokingDay;
             ApplyEdit();
         }
 
@@ -47,20 +52,10 @@ namespace ProjectsTM.UI.MainForm
 
             foreach (var d in selectedDays)
             {
-                if (!Deletable(d)) return;
+                if (!IsDeletableWokingDay(d)) return;
                 _days.Remove(d);
             }
             ApplyEdit();
-        }
-
-        private bool Deletable(CallenderDay selectedDay)
-        {
-            foreach (var w in _workItems)
-            {
-                if (w.Period.From.Equals(selectedDay)) return false;
-                if (w.Period.To.Equals(selectedDay)) return false;
-            }
-            return true;
         }
 
         private List<CallenderDay> GetSelectedDays()

--- a/ProjectsTM.ViewModel/ViewData.cs
+++ b/ProjectsTM.ViewModel/ViewData.cs
@@ -246,5 +246,15 @@ namespace ProjectsTM.ViewModel
             Original.ColorConditions = colorConditions;
             ColorConditionChanged?.Invoke(this, null);
         }
+
+        public bool IsDeletable(CallenderDay d)
+        {
+            foreach (var w in Original.WorkItems)
+            {
+                if (w.Period.From.Equals(d)) return false;
+                if (w.Period.To.Equals(d)) return false;
+            }
+            return true;
+        }
     }
 }


### PR DESCRIPTION
- ManagementWokingDaysFormが直接ViewDataを書き換えるのをやめる。
- コピーされたコレクションIEnumerable<CallenderDay>を参照するようにする。
- 追加/削除操作はコールバック関数でコレクションを投げてコールバック関数内でViewDataを書き換える。
- _workItemsを無くす。_workItemsを使って行っている「日付を削除可能かどうか」という判定を、コールバック関数内で行うようにする。
- 同じ日付が登録可能になっているのを直す。