### PR TITLE
最終更新者名が日本語の場合に文字化けする問題を修正。最終更新者名に丸括弧が表示されてしまう問題を修正

### DIFF
--- a/ProjectsTM.Service/GitCmdRepository.cs
+++ b/ProjectsTM.Service/GitCmdRepository.cs
@@ -97,6 +97,7 @@ namespace ProjectsTM.Service
                         RedirectStandardOutput = true,
                         UseShellExecute = false,
                         CreateNoWindow = true,
+                        StandardOutputEncoding = Encoding.UTF8,
                     };
                     process.Start();
 

--- a/ProjectsTM.Service/GitRepositoryService.cs
+++ b/ProjectsTM.Service/GitRepositoryService.cs
@@ -145,7 +145,7 @@ namespace ProjectsTM.Service
                 }
                 if (ulong.Parse(strResult) < ulong.Parse(strM)) result = matches[i];
             }
-            return result.Groups[1].Value;
+            return result.Groups[1].Value.Substring(1);
         }
     }
 }


### PR DESCRIPTION
users/matsukage/toolTipHistoryへのプルリクです。