### PR TITLE
アイテム幅可変化

### DIFF
--- a/ProjectsTM.Logic/KeyState.cs
+++ b/ProjectsTM.Logic/KeyState.cs
@@ -6,5 +6,6 @@ namespace ProjectsTM.Logic
     {
         public static bool IsControlDown => (Control.ModifierKeys & Keys.Control) == Keys.Control;
         public static bool IsShiftDown => (Control.ModifierKeys & Keys.Shift) == Keys.Shift;
+        public static bool IsAltDown => (Control.ModifierKeys & Keys.Alt) == Keys.Alt;
     }
 }

--- a/ProjectsTM.Service/KeyAndMouseHandleService.cs
+++ b/ProjectsTM.Service/KeyAndMouseHandleService.cs
@@ -244,7 +244,18 @@ namespace ProjectsTM.Service
 
         public void MouseWheel(MouseEventArgs e)
         {
-            if (KeyState.IsControlDown)
+            if (KeyState.IsControlDown && KeyState.IsAltDown)
+            {
+                if (e.Delta > 0)
+                {
+                    _viewData.IncWidth();
+                }
+                else
+                {
+                    _viewData.DecWidth();
+                }
+            }
+            else if(KeyState.IsControlDown)
             {
                 if (e.Delta > 0)
                 {

--- a/ProjectsTM.UI.Main/MainForm.Designer.cs
+++ b/ProjectsTM.UI.Main/MainForm.Designer.cs
@@ -56,6 +56,8 @@ namespace ProjectsTM.UI.Main
             this.ToolStripMenuItemColor = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStripMenuItemLargeRatio = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStripMenuItemSmallRatio = new System.Windows.Forms.ToolStripMenuItem();
+            this.ToolStripMenuItemWidenWidth = new System.Windows.Forms.ToolStripMenuItem();
+            this.ToolStripMenuItemNarrowWidth = new System.Windows.Forms.ToolStripMenuItem();
             this.管理ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStripMenuItemManageMember = new System.Windows.Forms.ToolStripMenuItem();
             this.ToolStripMenuItemMileStone = new System.Windows.Forms.ToolStripMenuItem();
@@ -214,7 +216,9 @@ namespace ProjectsTM.UI.Main
             this.ToolStripMenuItemFilter,
             this.ToolStripMenuItemColor,
             this.ToolStripMenuItemLargeRatio,
-            this.ToolStripMenuItemSmallRatio});
+            this.ToolStripMenuItemSmallRatio,
+            this.ToolStripMenuItemWidenWidth,
+            this.ToolStripMenuItemNarrowWidth});
             this.表示ToolStripMenuItem.Name = "表示ToolStripMenuItem";
             this.表示ToolStripMenuItem.Size = new System.Drawing.Size(58, 23);
             this.表示ToolStripMenuItem.Text = "表示(&V)";
@@ -223,7 +227,7 @@ namespace ProjectsTM.UI.Main
             // 
             this.ToolStripMenuItemFilter.Image = global::ProjectsTM.UI.Main.Properties.Resources.icons8_filter_24;
             this.ToolStripMenuItemFilter.Name = "ToolStripMenuItemFilter";
-            this.ToolStripMenuItemFilter.Size = new System.Drawing.Size(171, 22);
+            this.ToolStripMenuItemFilter.Size = new System.Drawing.Size(189, 22);
             this.ToolStripMenuItemFilter.Text = "フィルター(&F)";
             this.ToolStripMenuItemFilter.Click += new System.EventHandler(this.ToolStripMenuItemFilter_Click);
             // 
@@ -231,7 +235,7 @@ namespace ProjectsTM.UI.Main
             // 
             this.ToolStripMenuItemColor.Image = global::ProjectsTM.UI.Main.Properties.Resources.icons8_swatch_48;
             this.ToolStripMenuItemColor.Name = "ToolStripMenuItemColor";
-            this.ToolStripMenuItemColor.Size = new System.Drawing.Size(171, 22);
+            this.ToolStripMenuItemColor.Size = new System.Drawing.Size(189, 22);
             this.ToolStripMenuItemColor.Text = "色(&C)";
             this.ToolStripMenuItemColor.Click += new System.EventHandler(this.ToolStripMenuItemColor_Click);
             // 
@@ -240,7 +244,7 @@ namespace ProjectsTM.UI.Main
             this.ToolStripMenuItemLargeRatio.Name = "ToolStripMenuItemLargeRatio";
             this.ToolStripMenuItemLargeRatio.ShortcutKeyDisplayString = "Ctrl++";
             this.ToolStripMenuItemLargeRatio.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Oemplus)));
-            this.ToolStripMenuItemLargeRatio.Size = new System.Drawing.Size(171, 22);
+            this.ToolStripMenuItemLargeRatio.Size = new System.Drawing.Size(189, 22);
             this.ToolStripMenuItemLargeRatio.Text = "倍率(→大)";
             // 
             // ToolStripMenuItemSmallRatio
@@ -248,8 +252,26 @@ namespace ProjectsTM.UI.Main
             this.ToolStripMenuItemSmallRatio.Name = "ToolStripMenuItemSmallRatio";
             this.ToolStripMenuItemSmallRatio.ShortcutKeyDisplayString = "Ctrl+ー";
             this.ToolStripMenuItemSmallRatio.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.OemMinus)));
-            this.ToolStripMenuItemSmallRatio.Size = new System.Drawing.Size(171, 22);
+            this.ToolStripMenuItemSmallRatio.Size = new System.Drawing.Size(189, 22);
             this.ToolStripMenuItemSmallRatio.Text = "倍率(→小)";
+            // 
+            // ToolStripMenuItemWidenWidth
+            // 
+            this.ToolStripMenuItemWidenWidth.Name = "ToolStripMenuItemWidenWidth";
+            this.ToolStripMenuItemWidenWidth.ShortcutKeyDisplayString = "Ctrl+Alt++";
+            this.ToolStripMenuItemWidenWidth.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Alt) 
+            | System.Windows.Forms.Keys.Oemplus)));
+            this.ToolStripMenuItemWidenWidth.Size = new System.Drawing.Size(189, 22);
+            this.ToolStripMenuItemWidenWidth.Text = "幅を広げる";
+            // 
+            // ToolStripMenuItemNarrowWidth
+            // 
+            this.ToolStripMenuItemNarrowWidth.Name = "ToolStripMenuItemNarrowWidth";
+            this.ToolStripMenuItemNarrowWidth.ShortcutKeyDisplayString = "Ctrl+Alt+-";
+            this.ToolStripMenuItemNarrowWidth.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Alt) 
+            | System.Windows.Forms.Keys.OemMinus)));
+            this.ToolStripMenuItemNarrowWidth.Size = new System.Drawing.Size(189, 22);
+            this.ToolStripMenuItemNarrowWidth.Text = "幅を狭める";
             // 
             // 管理ToolStripMenuItem
             // 
@@ -385,6 +407,8 @@ namespace ProjectsTM.UI.Main
         private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemMySetting;
         private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemTrendChart;
         private System.Windows.Forms.ToolStripContainer toolStripContainer1;
+        private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemWidenWidth;
+        private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemNarrowWidth;
     }
 }
 

--- a/ProjectsTM.UI.Main/MainForm.cs
+++ b/ProjectsTM.UI.Main/MainForm.cs
@@ -56,6 +56,8 @@ namespace ProjectsTM.UI.Main
             this.ToolStripMenuItemAddWorkItem.Click += (s, e) => _workItemGrid.AddNewWorkItem(null);
             this.ToolStripMenuItemSaveAsOtherName.Click += (s, e) => _fileIOService.SaveOtherName(_viewData.Original, _taskListManager.ShowOverlapCheck);
             this.ToolStripMenuItemDivide.Click += (s, e) => _workItemGrid.Divide();
+            this.ToolStripMenuItemNarrowWidth.Click += (s, e) => _viewData.DecWidth();
+            this.ToolStripMenuItemWidenWidth.Click += (s, e) => _viewData.IncWidth();
         }
 
         private void SuggestSetting()
@@ -105,6 +107,10 @@ namespace ProjectsTM.UI.Main
         {
             var setting = UserSettingUIService.Load();
             _viewData.FontSize = setting.FontSize;
+            if (setting.ItemWidth != 0)
+            {
+                _viewData.ItemWidth = setting.ItemWidth;
+            }
             _viewData.Detail = setting.Detail;
             _patternHistory.CopyFrom(setting.PatternHistory);
             if (_fileIOService.TryOpenFile(setting.FilePath, out var appData))
@@ -125,6 +131,7 @@ namespace ProjectsTM.UI.Main
             {
                 FilterName = _filterComboBoxService.Text,
                 FontSize = _viewData.FontSize,
+                ItemWidth = _viewData.ItemWidth,
                 FilePath = _fileIOService.FilePath,
                 Detail = _viewData.Detail,
                 PatternHistory = _patternHistory,

--- a/ProjectsTM.UI.Main/WorkItemGrid.cs
+++ b/ProjectsTM.UI.Main/WorkItemGrid.cs
@@ -84,7 +84,8 @@ namespace ProjectsTM.UI.Main
             var calWidth = (int)Math.Ceiling(g.MeasureString("2000A12A31", font).Width);
             var memberHeight = (int)Math.Ceiling(g.MeasureString("NAME", font).Height);
             var height = memberHeight;
-            var width = (int)(Math.Ceiling(this.CreateGraphics().MeasureString("ABCDEF", font).Width) + 1);
+            string widthStr = new string('A', _viewData.ItemWidth);
+            var width = (int)(Math.Ceiling(this.CreateGraphics().MeasureString(widthStr, font).Width) + 1);
             this.ColWidths[WorkItemGridConstants.YearCol.Value] = (int)(calWidth / 2f) + 1;
             this.ColWidths[WorkItemGridConstants.MonthCol.Value] = (int)(calWidth / 4f) + 1;
             this.ColWidths[WorkItemGridConstants.DayCol.Value] = (int)(calWidth / 4f) + 1;

--- a/ProjectsTM.ViewModel/MainViewData.cs
+++ b/ProjectsTM.ViewModel/MainViewData.cs
@@ -48,6 +48,7 @@ namespace ProjectsTM.ViewModel
         }
 
         public int FontSize { get; set; } = 6;
+        public int ItemWidth { get; set; } = 6;
 
         public void DecRatio()
         {
@@ -62,6 +63,20 @@ namespace ProjectsTM.ViewModel
         {
             FontSize++;
             Detail.ViewRatio += 0.1f;
+            RatioChanged?.Invoke(this, null);
+        
+        }
+
+        public void DecWidth()
+        {
+            if (ItemWidth <= 1) return;
+            ItemWidth--;
+            RatioChanged?.Invoke(this, null);
+        }
+
+        public void IncWidth()
+        {
+            ItemWidth++;
             RatioChanged?.Invoke(this, null);
         }
 

--- a/ProjectsTM.ViewModel/UserSetting.cs
+++ b/ProjectsTM.ViewModel/UserSetting.cs
@@ -9,6 +9,7 @@ namespace ProjectsTM.ViewModel
         public string FilterName { get; set; }
         public float Ratio { get; set; }
         public int FontSize { get; set; }
+        public int ItemWidth { get; set; }
         public string FilePath { get; set; } = string.Empty;
         public Detail Detail { get; set; } = new Detail();
         public PatternHistory PatternHistory { get; set; } = new PatternHistory();
@@ -21,6 +22,7 @@ namespace ProjectsTM.ViewModel
             xml.Add(new XElement(nameof(FilterName)) { Value = FilterName.ToString() });
             xml.Add(new XElement(nameof(Ratio)) { Value = Ratio.ToString() });
             xml.Add(new XElement(nameof(FontSize)) { Value = FontSize.ToString() });
+            xml.Add(new XElement(nameof(ItemWidth)) { Value = ItemWidth.ToString() });
             xml.Add(new XElement(nameof(FilePath)) { Value = FilePath.ToString() });
             xml.Add(Detail.ToXml());
             xml.Add(PatternHistory.ToXml());
@@ -35,6 +37,10 @@ namespace ProjectsTM.ViewModel
             result.FilterName = xml.Element(nameof(FilterName)).Value;
             result.Ratio = float.Parse(xml.Element(nameof(Ratio)).Value);
             result.FontSize = int.Parse(xml.Element(nameof(FontSize)).Value);
+            if (xml.Element(nameof(ItemWidth)) != null)
+            {
+                result.ItemWidth = int.Parse(xml.Element(nameof(ItemWidth)).Value);
+            }
             if (xml.Element(nameof(FilePath)) != null)
             {
                 result.FilePath = xml.Element(nameof(FilePath)).Value;


### PR DESCRIPTION
wakakiです

文字サイズのみを変えたいという要望を出しましたが、要素の幅や高さがフォントサイズ基準になっていたので、代わりの機能としてCtrl + Alt + +/- および Ctrl + Alt + マウスホイール で表示アイテムの幅を拡大縮小する機能を実装しました。

以下を確認済みです
・UnitTest通過
・アイテム幅情報 ItemWidth を持っていない古いUserSetting.xmlでも例外にならず、デフォルト値で動作。